### PR TITLE
Fixes #45 - slack links

### DIFF
--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -69,7 +69,7 @@ const fullTitle = `${title} | 757 Tech Community`;
             <li><a href="/learning">Learning</a></li>
             <li><a href="/work">Work</a></li>
             <li><a href="/get-involved">Get Involved</a></li>
-            <li><a href="https://join.slack.com/t/757dev/shared_invite/zt-1wl4vpnw2-Hn8ygvlDJvnr4Ygcx1~1Qw" target="_blank" rel="noopener noreferrer">
+            <li><a href="https://join.slack.com/t/757dev/shared_invite/zt-37d031yip-yI9z3ez8ezf~mJTy5ICaeQ" target="_blank" rel="noopener noreferrer">
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" style="vertical-align: text-bottom; margin-right: 4px;">
                 <path d="M3.362 10.11c0 .926-.756 1.681-1.681 1.681S0 11.036 0 10.111C0 9.186.756 8.43 1.68 8.43h1.682v1.68zm.846 0c0-.924.756-1.68 1.681-1.68s1.681.756 1.681 1.68v4.21c0 .924-.756 1.68-1.68 1.68a1.685 1.685 0 0 1-1.682-1.68v-4.21zM5.89 3.362c-.926 0-1.682-.756-1.682-1.681S4.964 0 5.89 0s1.68.756 1.68 1.68v1.682H5.89zm0 .846c.924 0 1.68.756 1.68 1.681S6.814 7.57 5.89 7.57H1.68C.757 7.57 0 6.814 0 5.89c0-.926.756-1.682 1.68-1.682h4.21zm6.749 1.682c0-.926.755-1.682 1.68-1.682.925 0 1.681.756 1.681 1.681s-.756 1.681-1.68 1.681h-1.681V5.89zm-.848 0c0 .924-.755 1.68-1.68 1.68A1.685 1.685 0 0 1 8.43 5.89V1.68C8.43.757 9.186 0 10.11 0c.926 0 1.681.756 1.681 1.68v4.21zm-1.681 6.748c.926 0 1.682.756 1.682 1.681S11.036 16 10.11 16s-1.681-.756-1.681-1.68v-1.682h1.68zm0-.847c-.924 0-1.68-.755-1.68-1.68 0-.925.756-1.681 1.68-1.681h4.21c.924 0 1.68.756 1.68 1.68 0 .926-.756 1.681-1.68 1.681h-4.21z"/>
               </svg>

--- a/src/pages/get-involved.astro
+++ b/src/pages/get-involved.astro
@@ -36,7 +36,7 @@ import NewsletterSignup from '../components/NewsletterSignup.astro';
         <h2>Join Online Communities</h2>
         <p>
           Can't make it to in-person events? Join one of the many online communities for tech professionals 
-          in Hampton Roads. The <a href="https://757dev.org">757dev Slack</a> is a great place to start.
+          in Hampton Roads. The <a href="https://join.slack.com/t/757dev/shared_invite/zt-37d031yip-yI9z3ez8ezf~mJTy5ICaeQ">757dev Slack</a> is a great place to start.
         </p>
       </div>
 


### PR DESCRIPTION
Fixes #45 - slack links

This pull request updates outdated Slack invite links across the project to ensure users can access the correct invitation URLs.

### Updates to Slack invite links:

* [`src/layouts/MainLayout.astro`](diffhunk://#diff-ddde895c93027f02c64f4a4081247c0b4f2c7a14393cb9c4af28adb7cffed063L72-R72): Updated the Slack invite link in the navigation menu to the new URL.
* [`src/pages/get-involved.astro`](diffhunk://#diff-30b30ae015dc876e3e63f485ef01cc871d3fde336f3529738cb2db7d19c91a58L39-R39): Updated the Slack invite link in the "Join Online Communities" section to the new URL.