### PR TITLE
757 build weekend

### DIFF
--- a/src/data/calendar-events.json
+++ b/src/data/calendar-events.json
@@ -330,6 +330,16 @@
     "featuredEvent": true
   },
   {
+    "title": "757 Build Weekend",
+    "link": "https://757startupstudios.notion.site/757-Build-Weekend-1e255c587c1544cfbc742ba8dc21c0c8",
+    "date": "2025-06-27T16:00:00.000Z",
+    "description": "Hampton Roads’ first hackathon supported by the 757 Startup Studios and Assembly",
+    "source": "manual",
+    "group": "757 Startup Studios",
+    "createdDate": "2025-06-12T13:00:00.000Z",
+    "updatedDate": "2025-06-12T13:00:00.000Z"
+  },
+  {
     "title": "Bitcoin meetup Open Discussion",
     "link": "https://www.meetup.com/virginia-beach-bitcoin/events/kgcxptyhclbcc/",
     "date": "2025-08-21T22:30:00.000Z",

--- a/src/data/calendar-events.json
+++ b/src/data/calendar-events.json
@@ -337,7 +337,8 @@
     "source": "manual",
     "group": "757 Startup Studios",
     "createdDate": "2025-06-12T13:00:00.000Z",
-    "updatedDate": "2025-06-12T13:00:00.000Z"
+    "updatedDate": "2025-06-12T13:00:00.000Z",
+    "featuredEvent": true
   },
   {
     "title": "Bitcoin meetup Open Discussion",


### PR DESCRIPTION
This pull request adds a new event to the `calendar-events.json` file. The event is titled "757 Build Weekend" and includes details such as the date, description, source, group, and links.

Event addition:

* [`src/data/calendar-events.json`](diffhunk://#diff-03c921b83d210e89081f050cce3119f096037a8ae1a1afbcc0e075953434f1d2R332-R342): Added a new featured event, "757 Build Weekend," scheduled for June 27, 2025. This event is described as Hampton Roads' first hackathon, supported by 757 Startup Studios and Assembly.