### PR TITLE
Remove stale AI Collective HR event

### DIFF
--- a/src/data/calendar-events.json
+++ b/src/data/calendar-events.json
@@ -1,16 +1,5 @@
 [
   {
-    "title": "🧜‍♀️ The AI Collective HR • Connecting Hampton Roads AI Enthusiasts",
-    "link": "https://www.meetup.com/aicollectivehr/events/310091450/",
-    "date": "2025-11-25T23:00:00.000Z",
-    "description": "Join us for the inaugural gathering of the 757 AI Collective! Whether you're an AI professional, researcher, student, or simply curious about artificial intelligence, this meetup offers a relaxed environment to connect with fellow enthusiasts in the Hampton Roads area. Come share your interests, discuss the latest developments, and help shape the future of our local AI community.\n**Agenda:**\n\n* **Welcome & Introductions:** Meet the organizers and fellow attendees.\n* **Open Discussion:** Share your interests and what you hope to gain from the group.\n* **AI News Highlights:** Brief overview of recent major AI developments to spark conversation.\n* **Networking:** Engage in informal chats over refreshments.\n\n**Recent AI News Highlights:**\nTo kickstart our discussions, here are some notable AI developments from May 2025:\n\n* **Apple + Anthropic team up**\n* **Google announces Veo3 and AlphaEvolve**\n* **Bolt.new $1m Hackathon**\n* **New Deepseek, Claude, and Gemini models**\n\nWe look forward to seeing you there and building a vibrant AI community in the 757 area!",
-    "source": "meetup",
-    "group": "757 Artificial Intelligence Collective",
-    "featuredEvent": false,
-    "createdDate": "2025-08-20T18:05:48.297Z",
-    "updatedDate": "2025-09-18T18:06:38.254Z"
-  },
-  {
     "title": "Geeks at a Bar- Peninsula Happy Hour",
     "link": "https://www.meetup.com/757dev/events/311879544/",
     "date": "2025-11-26T00:30:00.000Z",


### PR DESCRIPTION
This PR removes the stale event "🧜‍♀️ The AI Collective HR • Connecting Hampton Roads AI Enthusiasts" from the calendar data.

The event scheduled for November 25, 2025 hasn't been updated since September 18, 2025 and appears to be cancelled or deleted from the source.

Closes #143

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the outdated "🧜‍♀️ The AI Collective HR • Connecting Hampton Roads AI Enthusiasts" entry from `src/data/calendar-events.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddd93d52c195a73fac3294358951aaf93ac38873. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->