### PR TITLE
Fix timezone display bug in weekly meetups generation

### DIFF
--- a/scripts/generate-weekly-meetups.js
+++ b/scripts/generate-weekly-meetups.js
@@ -53,24 +53,20 @@ function getCurrentWeekDates() {
   return { monday: mondayUTC, sunday };
 }
 
-// Function to format a date in a readable format
+// Function to format a date in a readable format (converts to Eastern Time)
 function formatDate(date) {
   const dateObj = new Date(date);
-  
-  // Get day of week
-  const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-  const dayOfWeek = days[dateObj.getDay()];
-  
-  // Get month
-  const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
-  const month = months[dateObj.getMonth()];
-  
-  // Get day and year
-  const day = dateObj.getDate();
-  const year = dateObj.getFullYear();
-  
-  // Format like "Monday, April 28"
-  return `${dayOfWeek}, ${month} ${day}`;
+
+  // Convert to Eastern Time for display
+  const options = {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'America/New_York'
+  };
+
+  // Format like "Monday, December 29"
+  return dateObj.toLocaleDateString('en-US', options);
 }
 
 // Function to format a date for the filename (YYYY-MM-DD)

--- a/weekly-meetups/2025-12-29-weekly-meetups-slack.txt
+++ b/weekly-meetups/2025-12-29-weekly-meetups-slack.txt
@@ -2,7 +2,7 @@
 
 *2 Meetups This Week*
 
-*Tuesday, December 30*
+*Monday, December 29*
 • *We're getting the band back together.* - 07:00 PM
   757 Python Users Group
   https://www.meetup.com/757-python-users-group/events/312554590/ (Event Link)

--- a/weekly-meetups/2025-12-29-weekly-meetups.md
+++ b/weekly-meetups/2025-12-29-weekly-meetups.md
@@ -1,10 +1,10 @@
 # Meetups This Week (Monday - Sunday)
 
-Generated on: 2025-12-29T06:06:27.921Z
+Generated on: 2025-12-29T15:19:34.219Z
 
 ## 2 Meetups This Week
 
-### Tuesday, December 30
+### Monday, December 29
 
 #### We're getting the band back together.
 


### PR DESCRIPTION
## Summary
- Fixed timezone bug in `formatDate()` function where UTC dates were displayed instead of Eastern Time
- Events stored as UTC (e.g., `2025-12-30T00:00:00.000Z`) now correctly display as their local Eastern Time equivalent (e.g., Monday, December 29 at 7:00 PM EST)
- Regenerated weekly meetups files with correct dates

## Test plan
- [x] Verified the 757 Python Users Group event now shows as Monday, December 29 (correct) instead of Tuesday, December 30 (incorrect)
- [x] Confirmed the fix uses `toLocaleDateString` with `America/New_York` timezone
- [x] Ran `node scripts/generate-weekly-meetups.js` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)