### PR TITLE
Add 757 BLD WKND 2026 hackathon event

### DIFF
--- a/src/data/calendar-events.json
+++ b/src/data/calendar-events.json
@@ -70,6 +70,17 @@
     "updatedDate": "2026-02-16T12:15:05.896Z"
   },
   {
+    "title": "757 BLD WKND 2026",
+    "link": "https://757-bld-wknd-2026.devpost.com/",
+    "date": "2026-02-20T13:00:00.000Z",
+    "description": "If you love to build and create, this event is for you! A high-energy, weekend-long experience where entrepreneurs, students, and professionals bring bold ideas to life and pitch for prizes and bragging rights. This event blends tech, gaming, music, AI, and hands-on exploration in a culture-rich, electrifying environment. Open to both technical and non-technical builders, it's a two-day opportunity to collaborate, find talent, and create together with 757 Startup Studios.",
+    "source": "community",
+    "group": "757 Startup Studios",
+    "featuredEvent": true,
+    "createdDate": "2026-02-16T15:23:03Z",
+    "updatedDate": "2026-02-16T15:23:03Z"
+  },
+  {
     "title": "Cybersecurity - Chesapeake Weekend Afternoon Networking (WAN)",
     "link": "https://www.meetup.com/issa-hampton-roads/events/313165184/",
     "date": "2026-02-20T23:00:00.000Z",


### PR DESCRIPTION
## Summary
- Adds the **757 BLD WKND 2026** (Feb 20-21) hackathon/build weekend event to `calendar-events.json`
- Community event by 757 Startup Studios, hosted on [Devpost](https://757-bld-wknd-2026.devpost.com/)
- Marked as a featured event, inserted in date-sorted order

## Test plan
- [x] `npm run validate` passes — JSON schema validation confirmed
- [ ] Verify event appears on the site calendar page
- [ ] Verify featured event badge renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)