### PR TITLE
Update GitHub Actions workflows to Node 20

### DIFF
--- a/.github/workflows/azure-static-web-apps-ashy-field-00e5f470f.yml
+++ b/.github/workflows/azure-static-web-apps-ashy-field-00e5f470f.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       # Setup Yarn
       - name: Setup Yarn
         run: npm install -g yarn

--- a/.github/workflows/process-event-submission.yml
+++ b/.github/workflows/process-event-submission.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'yarn'
           
       - name: Setup Yarn

--- a/.github/workflows/update-calendar.yml
+++ b/.github/workflows/update-calendar.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'yarn'
       
       - name: Setup Yarn

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
 
     - name: Install ajv-cli
       run: npm install -g ajv-cli ajv-formats

--- a/.github/workflows/weekly-meetups.yml
+++ b/.github/workflows/weekly-meetups.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'yarn'
       
       - name: Setup Yarn


### PR DESCRIPTION
## Summary
- Updates all 5 GitHub Actions workflow files from Node 18 to Node 20
- Fixes CI failure caused by `fontkitten` requiring Node >= 20
- Affected workflows: Azure SWA deploy, update-calendar, weekly-meetups, validate-json, process-event-submission

## Test plan
- [ ] Azure Static Web Apps CI/CD build passes
- [ ] Validate JSON workflow passes
- [ ] Calendar update workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)