### PR TITLE
fix: dedupe and tune stale-event check to reduce issue noise

### DIFF
--- a/scripts/check-stale-events.js
+++ b/scripts/check-stale-events.js
@@ -21,7 +21,10 @@ const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const GITHUB_REPO = process.env.GITHUB_REPOSITORY || 'your-org/757-community-site-public';
 
 // Configuration
-const STALE_THRESHOLD_HOURS = 12; // Consider events stale if not updated in the last 12 hours
+const STALE_THRESHOLD_HOURS = 48; // Consider events stale if not updated in the last 48 hours
+const MAX_FUTURE_DAYS = 180;      // Skip events more than ~6 months out — Meetup RSS feeds
+                                  // typically only carry near-term events, so distant events
+                                  // naturally fall off the feed without being cancelled.
 
 /**
  * Makes an HTTPS request
@@ -197,61 +200,91 @@ async function checkStaleEvents() {
     
     console.log(`Checking ${events.length} events for staleness...`);
     
-    // Calculate the stale threshold
+    // Calculate the stale threshold and the future-event cutoff
     const now = new Date();
     const staleThreshold = new Date(now.getTime() - (STALE_THRESHOLD_HOURS * 60 * 60 * 1000));
-    
+    const futureCutoff = new Date(now.getTime() + (MAX_FUTURE_DAYS * 24 * 60 * 60 * 1000));
+
     console.log(`Events last updated before ${staleThreshold.toISOString()} will be considered stale`);
-    
+    console.log(`Skipping events scheduled after ${futureCutoff.toISOString()} (more than ${MAX_FUTURE_DAYS} days out)`);
+
     // Find stale events
     const staleEvents = events.filter(event => {
       // Only check Meetup events for staleness
       if (event.source !== 'meetup') {
         return false;
       }
-      
+
+      // Skip events that have already happened — no point flagging the past
+      if (event.date) {
+        const eventDate = new Date(event.date);
+        if (eventDate < now) {
+          return false;
+        }
+        // Skip events too far in the future
+        if (eventDate > futureCutoff) {
+          return false;
+        }
+      }
+
       if (!event.updatedDate) {
         // Events without updatedDate are considered stale
         return true;
       }
-      
+
       const updatedDate = new Date(event.updatedDate);
       return updatedDate < staleThreshold;
     });
-    
+
     console.log(`Found ${staleEvents.length} stale events`);
-    
-    if (staleEvents.length === 0) {
+
+    // Dedupe within this run by title — recurring events (e.g. "Geeks at a Bar"
+    // happy hour) appear in calendar-events.json once per occurrence, so without
+    // this we'd file one issue per occurrence on every run.
+    const seenInRun = new Set();
+    const dedupedStaleEvents = staleEvents.filter(event => {
+      if (seenInRun.has(event.title)) {
+        return false;
+      }
+      seenInRun.add(event.title);
+      return true;
+    });
+
+    if (dedupedStaleEvents.length < staleEvents.length) {
+      console.log(`Deduped to ${dedupedStaleEvents.length} unique stale events (collapsed ${staleEvents.length - dedupedStaleEvents.length} recurring duplicates)`);
+    }
+
+    if (dedupedStaleEvents.length === 0) {
       console.log('No stale events found, no issues to create');
       return;
     }
-    
-    // Get existing issues to avoid duplicates
+
+    // Get existing issues to avoid duplicates across runs
     const existingIssues = await getExistingIssues();
     const existingEventTitles = new Set(
-      existingIssues.map(issue => 
+      existingIssues.map(issue =>
         issue.title.replace('🗑️ Review stale event: ', '')
       )
     );
-    
+
     // Create issues for stale events that don't already have issues
     let issuesCreated = 0;
-    for (const event of staleEvents) {
+    for (const event of dedupedStaleEvents) {
       if (!existingEventTitles.has(event.title)) {
         const issue = await createStaleEventIssue(event);
         if (issue) {
           issuesCreated++;
         }
-        
+
         // Rate limiting - wait 1 second between issue creation
-        if (issuesCreated < staleEvents.length) {
+        if (issuesCreated < dedupedStaleEvents.length) {
           await new Promise(resolve => setTimeout(resolve, 1000));
         }
       } else {
         console.log(`⏭️ Skipping ${event.title} - issue already exists`);
       }
     }
-    
+
     console.log(`✅ Stale event check completed. Created ${issuesCreated} new issues.`);
     
   } catch (error) {


### PR DESCRIPTION
## Why

The stale-event check (`scripts/check-stale-events.js`) was filing one issue per occurrence of a recurring meetup on every 6-hour run, producing bursts of 10+ duplicates whenever a Meetup RSS feed temporarily dropped events. Today's run alone filed 13 issues — see #210–#222 — and the closed history shows this loop repeating every few weeks (recent example: 25 issues bulk-closed at 15:10 UTC today, then 13 new ones opened at 18:35 UTC).

## What changed

Three fixes in `scripts/check-stale-events.js`:

1. **In-run dedupe by title.** Previous code only deduped against issues already on GitHub, not against issues created earlier in the same loop. So 7 future occurrences of "Geeks at a Bar — Peninsula Happy Hour" all became 7 separate issues.
2. **Date filter.** Skip events whose date is in the past (nothing to action) or more than ~6 months out (Meetup RSS feeds typically only carry near-term events; distant events fall off naturally without being cancelled).
3. **Threshold 12h → 48h.** Stops transient feed blips from tripping the check.

## Verification

Dry-run against current `src/data/calendar-events.json`:

```
Total events: 60
Stale (new logic): 12
After in-run dedup: 3
---unique titles flagged---
 - Geeks at a Bar- Peninsula Happy Hour (2026-05-26)
 - 🧜‍♀️ AICHR | Late Night Builders (2026-06-04)
 - Late Night Builders (2026-08-07)
---collapsed duplicates---
  6x Geeks at a Bar- Peninsula Happy Hour
  4x 🧜‍♀️ AICHR | Late Night Builders
  2x Late Night Builders
```

That's **12 → 3 issues per run, a 75% reduction**, on the exact same data that produced today's noise.

## Test plan

- [ ] CI green
- [ ] After merge, watch the next `update-calendar.yml` run (every 6h) and confirm only 0–3 new stale-event issues are filed
- [ ] If the noise stops, separately bulk-close #210–#222 (the existing duplicates from today's pre-fix runs)

## Notes

- Cross-feed alias collisions (e.g. "Late Night Builders" vs "🧜‍♀️ AICHR | Late Night Builders" — same physical event, two RSS feed sources) are *not* fixed here. That's properly fixed in the calendar dedup pipeline (`scripts/deduplicate-calendar.js`), not in the stale-event check. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)