### PR TITLE
Skip Claude Code Review on bot-authored PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+    # Skip automated/bot PRs (e.g. Renovate dependency bumps); the action
+    # blocks bot-initiated runs by default, so reviewing them only adds noise.
+    if: ${{ github.event.pull_request.user.type != 'Bot' }}
+
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## What

Guards the `claude-review` job with `if: github.event.pull_request.user.type != 'Bot'` so it only runs on human-authored PRs.

## Why

`anthropics/claude-code-action@v1` blocks bot-initiated runs by default. On every Renovate dependency PR the job failed with:

> Action failed with error: Workflow initiated by non-human actor: renovate (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

This produced a noisy red ❌ check on every dependency bump (#185, #234, #235) and burned Actions minutes for a review that never ran. Skipping bot PRs removes the noise while keeping reviews on the PRs that matter — the human ones.

Alternative considered: adding `allowed_bots: "renovate[bot]"` to actually review bot PRs. Opted against it since AI review of lockfile bumps adds little value.