### PR TITLE
Remove deleted stale event (Geeks at a Bar, #239)

### DIFF
--- a/src/data/calendar-events.json
+++ b/src/data/calendar-events.json
@@ -214,17 +214,6 @@
     "updatedDate": "2026-06-05T13:03:34.567Z"
   },
   {
-    "title": "Geeks at a Bar- Peninsula Happy Hour",
-    "link": "https://www.meetup.com/757dev/events/jnvfvsyjcjbfc/",
-    "date": "2026-06-23T23:30:00.000Z",
-    "description": "Do you work with technology or for a tech company? Do you speak geek? Come network with other technology industry workers for a casual, conversational happy hour.\n\nThis meetup is loosely organized, but very consistently scheduled. If you want to meet up somewhere else, share it in the #peninsula channel at 757dev.org Slack, or in the comments.",
-    "source": "meetup",
-    "group": "757 Developers",
-    "featuredEvent": false,
-    "createdDate": "2025-09-05T06:06:13.764Z",
-    "updatedDate": "2026-03-02T18:15:21.364Z"
-  },
-  {
     "title": "Cybersecurity Social/Happy Hour meetup for networking, meeting new people",
     "link": "https://www.meetup.com/issa-hampton-roads/events/314678919/",
     "date": "2026-06-24T22:00:00.000Z",


### PR DESCRIPTION
## What

Removes one event from `src/data/calendar-events.json`:
**"Geeks at a Bar- Peninsula Happy Hour"** (`757dev/events/jnvfvsyjcjbfc`, 2026-06-23).

## Why

Flagged by stale-event review issue #239. Verified against the Meetup source — the event URL now returns **HTTP 404**, so it was deleted upstream but lingered in the calendar with a stale `updatedDate` of 2026-03-02.

## Review of the other 12 stale-event issues

Cross-referenced all 13 open `stale-event` issues against the live calendar and Meetup sources. This was the **only** genuinely-deleted event still present. The rest were past events already removed, exact duplicates, or false positives (valid future events beyond Meetup's RSS refresh window). Those issues are being closed separately with notes.

Closes #239