### PR TITLE
Add BSides Hampton Roads 2026 as featured event

### DIFF
--- a/src/data/calendar-events.json
+++ b/src/data/calendar-events.json
@@ -1,5 +1,16 @@
 [
   {
+    "title": "BSides Hampton Roads 2026",
+    "link": "https://bsideshamptonroads.org/",
+    "date": "2026-10-09T13:00:00.000Z",
+    "description": "A community-driven cybersecurity conference built to connect, educate, and inspire the Hampton Roads security community. Part of the global Security BSides movement, it offers an open and collaborative environment where professionals, students, researchers, and technology enthusiasts can share ideas, exchange knowledge, and build meaningful connections.\n\nOctober 9-10, 2026 at the ODU Webb University Center.",
+    "source": "manual",
+    "group": "BSides Hampton Roads",
+    "featuredEvent": true,
+    "createdDate": "2026-06-16T14:00:44.000Z",
+    "updatedDate": "2026-06-16T14:00:44.000Z"
+  },
+  {
     "title": "Norfolk Cybersecurity Networking & Happy Hour",
     "link": "https://www.meetup.com/issa-hampton-roads/events/314975807/",
     "date": "2026-06-16T22:00:00.000Z",


### PR DESCRIPTION
## Summary
Adds **BSides Hampton Roads 2026** as a featured event on the calendar page.

- **What:** BSides Hampton Roads — a community-driven cybersecurity conference, part of the global Security BSides movement
- **When:** October 9–10, 2026
- **Where:** ODU Webb University Center
- **Link:** https://bsideshamptonroads.org/

The entry is added to `src/data/calendar-events.json` with `featuredEvent: true`, which the calendar page (`src/pages/calendar.astro`) renders in its dedicated Featured section. Description and tagline are taken from the official conference site.

## Why this approach
- `calendar.astro` filters `calendar-events.json` for `featuredEvent === true` — that's the live path that renders the featured section.
- `scripts/update-calendar.js` preserves existing entries and their `featuredEvent` flag during the 6-hourly RSS merge, only dropping past-dated events. So this manual entry persists across automatic refreshes until the event passes.
- Event date (Oct 9, 2026) falls inside the calendar's 6-month upcoming window, so it displays.

## Notes
- Start time is set to a placeholder of 09:00 ET (`2026-10-09T13:00:00.000Z`) since exact times aren't yet published on the site.

## Test plan
- [x] `node` parses `calendar-events.json`; BSides is the only `featuredEvent`
- [x] `npm run validate` passes
- [ ] `npm run dev` and confirm BSides appears in the calendar page's Featured section
