### PR TITLE
Add Virginia Cup startup qualifier as featured event

### DIFF
--- a/src/data/calendar-events.json
+++ b/src/data/calendar-events.json
@@ -518,6 +518,17 @@
     "updatedDate": "2026-06-16T14:00:44.000Z"
   },
   {
+    "title": "Virginia Cup: Official Startup World Cup Virginia Qualifier",
+    "link": "https://www.innovate757.org/vacup/",
+    "date": "2026-09-17T21:00:00.000Z",
+    "description": "Virginia's premier startup pitch competition and the official regional qualifier for the global Startup World Cup. Virginia's top entrepreneurs pitch for a chance to advance toward $1,000,000 in investment capital, with high-energy pitches, dynamic networking, and opportunities to connect with mentors, startups, investors, and innovation leaders.\n\nNow in its third year, the Virginia Cup is presented by Innovate Hampton Roads in partnership with Pegasus Tech Ventures and the Virginia Innovation Partnership Council (VIPC). The program features 10 startup pitches and the announcement of the Virginia Champion. A previous Virginia winner, ivWatch, advanced to third place in the global Startup World Cup.\n\nSeptember 17, 2026, 5:00–8:00 PM (doors at 5:00, program at 5:40 sharp) at the Sandler Center for the Performing Arts, 201 Market St, Virginia Beach, VA 23462. Optional pre-party from 3:00–5:00 PM at The Hive (140 Independence Blvd). Register to attend at https://ti.to/innovate757/startup-world-cup-virginia-qualifier-2026.",
+    "source": "manual",
+    "group": "Innovate Hampton Roads",
+    "featuredEvent": true,
+    "createdDate": "2026-06-22T13:29:12.000Z",
+    "updatedDate": "2026-06-22T13:29:12.000Z"
+  },
+  {
     "title": "Bitcoin meetup Open Discussion",
     "link": "https://www.meetup.com/virginia-beach-bitcoin/events/kgcxptyjcnbtb/",
     "date": "2026-10-15T22:30:00.000Z",


### PR DESCRIPTION
## Summary

Adds **Virginia Cup: Official Startup World Cup Virginia Qualifier** to `calendar-events.json` as a featured event, alongside BSides Hampton Roads.

Event details sourced from [innovate757.org/vacup](https://www.innovate757.org/vacup/) and the [ti.to registration page](https://ti.to/innovate757/startup-world-cup-virginia-qualifier-2026):

- **When:** September 17, 2026, 5:00–8:00 PM (doors 5:00, program 5:40 sharp)
- **Where:** Sandler Center for the Performing Arts, 201 Market St, Virginia Beach, VA 23462
- **Host:** Innovate Hampton Roads (in partnership with Pegasus Tech Ventures and VIPC)
- **Format:** 10 startup pitches + Virginia Champion announcement; optional 3:00–5:00 PM pre-party at The Hive

Matches the existing BSides entry structure: `source: manual`, `featuredEvent: true`.

## Test plan

- [x] `calendar-events.json` parses as valid JSON
- [x] `npm run validate` passes