### PR TITLE
Restyle newsletter thank-you page with coastal theme

### DIFF
--- a/src/components/landing/LandingFooter.astro
+++ b/src/components/landing/LandingFooter.astro
@@ -1,6 +1,15 @@
 ---
 import { COMMUNITY } from "../../data/community";
 const { slack: SLACK, discord: DISCORD, github: GITHUB } = COMMUNITY;
+
+// `subpage`: the anchor targets live on the landing page, so links get a
+// "/" prefix when the footer renders anywhere else.
+interface Props {
+  subpage?: boolean;
+}
+const { subpage = false } = Astro.props;
+const root = subpage ? "/" : "";
+
 // Evaluated at build time. The calendar auto-update redeploys the site every
 // ~6 hours (update-calendar.yml), so this rolls over within hours of Jan 1.
 const year = new Date().getFullYear();
@@ -14,16 +23,16 @@ const year = new Date().getFullYear();
     <div class="footer-cols">
       <div class="footer-col">
         <h4>Explore</h4>
-        <a href="#events">Events</a>
-        <a href="#conferences">Conferences</a>
-        <a href="#groups">Groups</a>
+        <a href={`${root}#events`}>Events</a>
+        <a href={`${root}#conferences`}>Conferences</a>
+        <a href={`${root}#groups`}>Groups</a>
         <a href="/calendar">Full calendar</a>
       </div>
       <div class="footer-col">
         <h4>Get involved</h4>
-        <a href="#submit">Submit an event</a>
+        <a href={`${root}#submit`}>Submit an event</a>
         <a href="/get-involved">Add your group</a>
-        <a href="#subscribe">Newsletter</a>
+        <a href={`${root}#subscribe`}>Newsletter</a>
       </div>
       <div class="footer-col">
         <h4>Connect</h4>

--- a/src/components/landing/LandingHeader.astro
+++ b/src/components/landing/LandingHeader.astro
@@ -1,7 +1,17 @@
 ---
 // Sticky coastal header. Real Slack/Discord invite URLs reused from the site.
+// `subpage` is set on pages other than the landing page: the anchor targets
+// live on the landing page (so links get a "/" prefix) and the brand stays
+// visible since there's no hero logo above it.
 import { COMMUNITY } from "../../data/community";
 const { slack: SLACK, discord: DISCORD } = COMMUNITY;
+
+interface Props {
+  subpage?: boolean;
+}
+const { subpage = false } = Astro.props;
+const root = subpage ? "/" : "";
+
 const links = [
   ["Events", "#events"],
   ["Conferences", "#conferences"],
@@ -9,13 +19,13 @@ const links = [
   ["Submit", "#submit"],
 ];
 ---
-<header class="site-header" id="site-header">
+<header class:list={["site-header", { subpage }]} id="site-header">
   <div class="header-inner">
-    <a class="brand" href="#top" aria-label="757tech home">
+    <a class="brand" href={subpage ? "/" : "#top"} aria-label="757tech home">
       <img src="/images/757tech-logo.png" alt="757tech — tech community" />
     </a>
     <nav class="nav" id="primary-nav" aria-label="Main navigation">
-      {links.map(([label, href]) => <a href={href}>{label}</a>)}
+      {links.map(([label, href]) => <a href={root + href}>{label}</a>)}
     </nav>
     <div class="header-social">
       <a class="social-ico slack" href={SLACK} target="_blank" rel="noopener noreferrer" aria-label="Join us on Slack" title="Join us on Slack">
@@ -36,7 +46,7 @@ const links = [
         <line x1="3" y1="18" x2="21" y2="18"></line>
       </svg>
     </button>
-    <a class="btn-coral header-cta" href="#subscribe">Subscribe</a>
+    <a class="btn-coral header-cta" href={`${root}#subscribe`}>Subscribe</a>
   </div>
 </header>
 

--- a/src/pages/newsletter-thank-you.astro
+++ b/src/pages/newsletter-thank-you.astro
@@ -1,84 +1,108 @@
 ---
-import MainLayout from '../layouts/MainLayout.astro';
+import LandingLayout from "../layouts/LandingLayout.astro";
+import LandingHeader from "../components/landing/LandingHeader.astro";
+import LandingFooter from "../components/landing/LandingFooter.astro";
 ---
 
-<MainLayout 
-	title="Thank You for Subscribing" 
+<LandingLayout
+	title="Thank You for Subscribing"
 	description="Thank you for subscribing to the 757tech newsletter. Stay tuned for weekly updates, special event offers, and volunteer opportunities in Hampton Roads."
 >
-	<div class="container">
-		<section class="section thank-you-section">
-			<h1>Welcome to the 757tech Community! 🎉</h1>
-			<p>
-				Thanks for joining our newsletter. You'll now receive:
-			</p>
-			<ul>
-				<li>Weekly updates on tech events, meetups, and happenings across Hampton Roads</li>
-				<li>Exclusive offers and early access to major events like Hampton Roads DevFest and RevolutionConf</li>
-				<li>Opportunities to volunteer and make an impact in our growing tech community</li>
-			</ul>
-			<p>
-				Your first update is on its way! In the meantime, check out our upcoming events and see how you can get involved.
-			</p>
-			<div class="cta-container">
-				<a href="/" class="cta-button">Return to Home</a>
+	<LandingHeader subpage />
+	<main>
+		<section class="section thanks">
+			<div class="thanks-card">
+				<span class="kicker">Newsletter</span>
+				<h1>Welcome to the 757tech community! 🎉</h1>
+				<p class="thanks-lead">Thanks for joining our newsletter. You'll now receive:</p>
+				<ul class="thanks-list">
+					<li>Weekly updates on tech events, meetups, and happenings across Hampton Roads</li>
+					<li>Exclusive offers and early access to major events like Hampton Roads DevFest and RevolutionConf</li>
+					<li>Opportunities to volunteer and make an impact in our growing tech community</li>
+				</ul>
+				<p class="thanks-lead">
+					Your first update is on its way! In the meantime, check out our upcoming events and see how you can get involved.
+				</p>
+				<div class="thanks-actions">
+					<a class="btn-coral" href="/#events">Browse upcoming events</a>
+					<a class="btn-ghost" href="/get-involved">Get involved</a>
+				</div>
 			</div>
 		</section>
-	</div>
-</MainLayout>
+	</main>
+	<LandingFooter subpage />
+</LandingLayout>
 
 <style>
-	.thank-you-section {
-		max-width: 800px;
-		margin: 4rem auto;
+	.thanks {
+		display: flex;
+		justify-content: center;
+	}
+
+	.thanks-card {
+		max-width: 720px;
 		text-align: center;
-		background-color: #fff;
-		padding: 3rem;
-		border-radius: 12px;
-		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+		background: var(--sand-soft);
+		border: 1px solid var(--line);
+		border-radius: 24px;
+		padding: clamp(36px, 5vw, 56px);
+		box-shadow: var(--shadow);
 	}
 
 	h1 {
-		color: #0077cc;
-		margin-bottom: 1.5rem;
+		font-size: clamp(30px, 4.5vw, 46px);
+		font-weight: 800;
+		color: var(--deep);
+		text-wrap: balance;
 	}
 
-	ul {
+	.thanks-lead {
+		color: var(--muted);
+		font-size: 17px;
+		line-height: 1.55;
+		margin: 18px 0 0;
+	}
+
+	.thanks-list {
 		list-style: none;
 		padding: 0;
-		margin: 2rem 0;
+		margin: 26px 0;
+		display: grid;
+		gap: 12px;
+		text-align: left;
 	}
 
-	li {
-		margin: 1rem 0;
-		font-size: 1.1rem;
-		color: #333;
+	.thanks-list li {
+		display: flex;
+		gap: 12px;
+		align-items: flex-start;
+		background: #fff;
+		border: 1px solid var(--line);
+		border-radius: 14px;
+		padding: 14px 16px;
+		color: var(--ink);
+		line-height: 1.5;
 	}
 
-	p {
-		font-size: 1.1rem;
-		line-height: 1.6;
-		color: #444;
-		margin: 1.5rem 0;
+	.thanks-list li::before {
+		content: "✓";
+		flex-shrink: 0;
+		width: 24px;
+		height: 24px;
+		border-radius: 50%;
+		display: grid;
+		place-items: center;
+		background: var(--seafoam);
+		color: var(--deep);
+		font-weight: 700;
+		font-size: 13px;
 	}
 
-	.cta-container {
-		margin-top: 3rem;
+	.thanks-actions {
+		display: flex;
+		gap: 12px;
+		justify-content: center;
+		flex-wrap: wrap;
+		margin-top: 30px;
 	}
-
-	.cta-button {
-		display: inline-block;
-		background-color: #0077cc;
-		color: white;
-		padding: 0.75rem 1.5rem;
-		border-radius: 4px;
-		font-weight: bold;
-		text-decoration: none;
-		transition: background-color 0.2s ease;
-	}
-
-	.cta-button:hover {
-		background-color: #005fa3;
-		text-decoration: none;
-	}
-</style> 
+</style>

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -89,7 +89,8 @@ section[id], #subscribe { scroll-margin-top: 86px; }
 /* At the top of the page the hero shows the prominent logo, so the navbar
    brand is hidden; it fades in (small) once the header condenses on scroll. */
 .brand { opacity: 0; pointer-events: none; transition: opacity .25s ease; }
-.site-header.scrolled .brand { opacity: 1; pointer-events: auto; }
+.site-header.scrolled .brand,
+.site-header.subpage .brand { opacity: 1; pointer-events: auto; }
 .brand img { height: 50px; width: auto; }
 .nav { display: flex; gap: 28px; margin-left: auto; }
 .nav a { font-weight: 600; font-size: 15.5px; color: var(--deep); position: relative; padding: 4px 0; opacity: .82; transition: opacity .15s; }


### PR DESCRIPTION
## Summary
- Subscribers sign up on the redesigned coastal landing page but were redirected to `/newsletter-thank-you`, which still rendered in the legacy blue theme (`#0077cc`, plain white card, old MainLayout chrome).
- Rebuilt the page on `LandingLayout` with the landing header/footer and coastal design tokens: sand-soft card, Baloo 2 headings, seafoam checkmark list, coral/ghost pill CTAs pointing at `/#events` and `/get-involved`. Copy is unchanged.
- Added a `subpage` prop to `LandingHeader`/`LandingFooter` so they work off the landing page: in-page anchors (`#events`, `#subscribe`, …) get a `/` prefix, the brand links home, and the navbar brand stays visible (no hero logo above it). This also makes the coastal chrome reusable for future inner-page migrations.

## Test plan
- [x] `npm run build` passes (76 pages)
- [x] Screenshot-verified `/newsletter-thank-you` renders in the coastal theme with working header/footer links
- [x] Screenshot-verified the landing page is unaffected (brand still hidden at top until scroll, anchors unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)