### PR TITLE
Fix stale-event false positives and collapse cross-posted events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ package-lock.json
 
 # backup files
 *.backup
+*.bak
 
 # Design handoff artifacts (kept locally, not tracked)
 design-reference/

--- a/scripts/check-stale-events.js
+++ b/scripts/check-stale-events.js
@@ -73,12 +73,20 @@ function makeRequest(url, options = {}, data = null) {
 
 /**
  * Asks the source whether an event has actually been deleted.
- * Errors and unexpected statuses resolve to false so that a flaky network or a
- * Meetup layout change results in a missed issue rather than a false accusation.
+ *
+ * Only a hard 404/410 counts as deleted. Anything else — a timeout, a network error,
+ * an unexpected status — resolves to "not deleted" so that a flaky check misses an
+ * issue rather than reporting a live event as cancelled.
+ *
+ * This assumes Meetup serves 404 for deleted events rather than redirecting or serving
+ * a 200 "not found" page. That holds today (verified against deleted events), but if it
+ * ever changes this step would quietly stop confirming anything, so the status code is
+ * returned and logged rather than collapsed into a bare boolean.
+ *
  * @param {string} url - The event URL to check
- * @returns {Promise<boolean>} - True only if the source confirms the event is gone
+ * @returns {Promise<{deleted: boolean, status: number|null, reason: string}>}
  */
-function isEventDeleted(url) {
+function checkEventAtSource(url) {
   return new Promise((resolve) => {
     let settled = false;
     const finish = (value) => {
@@ -97,19 +105,29 @@ function isEventDeleted(url) {
           timeout: 10000,
         },
         (res) => {
+          const status = res.statusCode;
+          // A HEAD response has no body, but drain it anyway and swallow any stream
+          // error so a mid-response socket failure can't throw unhandled.
+          res.on('error', () => finish({ deleted: false, status, reason: 'response stream error' }));
           res.resume();
-          finish(DELETED_STATUS_CODES.has(res.statusCode));
+          finish({
+            deleted: DELETED_STATUS_CODES.has(status),
+            status,
+            reason: `HTTP ${status}`,
+          });
         }
       );
 
       req.on('timeout', () => {
         req.destroy();
-        finish(false);
+        finish({ deleted: false, status: null, reason: 'timeout' });
       });
-      req.on('error', () => finish(false));
+      req.on('error', (error) =>
+        finish({ deleted: false, status: null, reason: `request error: ${error.message}` })
+      );
       req.end();
-    } catch {
-      finish(false);
+    } catch (error) {
+      finish({ deleted: false, status: null, reason: `request threw: ${error.message}` });
     }
   });
 }
@@ -321,11 +339,12 @@ async function checkStaleEvents() {
         continue;
       }
 
-      if (await isEventDeleted(event.link)) {
-        console.log(`🗑️ ${event.title} - confirmed deleted at source`);
+      const { deleted, reason } = await checkEventAtSource(event.link);
+      if (deleted) {
+        console.log(`🗑️ ${event.title} - confirmed deleted at source (${reason})`);
         confirmedStaleEvents.push(event);
       } else {
-        console.log(`✅ ${event.title} - still live at source, not stale (likely truncated off the RSS feed)`);
+        console.log(`✅ ${event.title} - still at source (${reason}), not stale (likely truncated off the RSS feed)`);
       }
 
       // Be polite to Meetup between checks

--- a/scripts/check-stale-events.js
+++ b/scripts/check-stale-events.js
@@ -84,7 +84,8 @@ function makeRequest(url, options = {}, data = null) {
  * returned and logged rather than collapsed into a bare boolean.
  *
  * @param {string} url - The event URL to check
- * @returns {Promise<{deleted: boolean, status: number|null, reason: string}>}
+ * @returns {Promise<{deleted: boolean, status: number|null, reason: string}>} - status is
+ *   null when no response arrived (timeout, network error, malformed URL)
  */
 function checkEventAtSource(url) {
   return new Promise((resolve) => {
@@ -106,9 +107,12 @@ function checkEventAtSource(url) {
         },
         (res) => {
           const status = res.statusCode;
-          // A HEAD response has no body, but drain it anyway and swallow any stream
-          // error so a mid-response socket failure can't throw unhandled.
-          res.on('error', () => finish({ deleted: false, status, reason: 'response stream error' }));
+          // The status line is all we need, and it's already here — resolve on it
+          // immediately. A HEAD response has no body, but drain it anyway and swallow
+          // any stream error: 'error' is always async, so it can never change the value
+          // resolved below. This listener exists purely so a mid-response socket failure
+          // can't throw as an unhandled 'error' event.
+          res.on('error', () => {});
           res.resume();
           finish({
             deleted: DELETED_STATUS_CODES.has(status),
@@ -327,12 +331,36 @@ async function checkStaleEvents() {
       return;
     }
 
+    // Get existing issues to avoid duplicates across runs. This happens before the
+    // source confirmation below so that an event which already has an open issue
+    // doesn't get re-checked against Meetup on every scheduled run — the issue
+    // wouldn't be filed twice either way, so the request would be pure waste.
+    const existingIssues = await getExistingIssues();
+    const existingEventTitles = new Set(
+      existingIssues.map(issue =>
+        issue.title.replace('🗑️ Review stale event: ', '')
+      )
+    );
+
+    const unreportedStaleEvents = dedupedStaleEvents.filter(event => {
+      if (existingEventTitles.has(event.title)) {
+        console.log(`⏭️ Skipping ${event.title} - issue already exists`);
+        return false;
+      }
+      return true;
+    });
+
+    if (unreportedStaleEvents.length === 0) {
+      console.log('All stale candidates already have open issues, nothing to do');
+      return;
+    }
+
     // Falling out of the RSS feed is only a hint. Confirm each candidate against the
     // source so that events truncated off the end of a busy feed aren't reported as
     // cancelled. Events with no link can't be confirmed, so they pass through.
-    console.log(`Confirming ${dedupedStaleEvents.length} stale candidates against the source...`);
+    console.log(`Confirming ${unreportedStaleEvents.length} stale candidates against the source...`);
     const confirmedStaleEvents = [];
-    for (const event of dedupedStaleEvents) {
+    for (const event of unreportedStaleEvents) {
       if (!event.link) {
         console.log(`❓ ${event.title} - no link to verify, flagging for review`);
         confirmedStaleEvents.push(event);
@@ -356,29 +384,17 @@ async function checkStaleEvents() {
       return;
     }
 
-    // Get existing issues to avoid duplicates across runs
-    const existingIssues = await getExistingIssues();
-    const existingEventTitles = new Set(
-      existingIssues.map(issue =>
-        issue.title.replace('🗑️ Review stale event: ', '')
-      )
-    );
-
-    // Create issues for stale events that don't already have issues
+    // Create issues for the confirmed stale events
     let issuesCreated = 0;
     for (const event of confirmedStaleEvents) {
-      if (!existingEventTitles.has(event.title)) {
-        const issue = await createStaleEventIssue(event);
-        if (issue) {
-          issuesCreated++;
-        }
+      const issue = await createStaleEventIssue(event);
+      if (issue) {
+        issuesCreated++;
+      }
 
-        // Rate limiting - wait 1 second between issue creation
-        if (issuesCreated < confirmedStaleEvents.length) {
-          await new Promise(resolve => setTimeout(resolve, 1000));
-        }
-      } else {
-        console.log(`⏭️ Skipping ${event.title} - issue already exists`);
+      // Rate limiting - wait 1 second between issue creation
+      if (issuesCreated < confirmedStaleEvents.length) {
+        await new Promise(resolve => setTimeout(resolve, 1000));
       }
     }
 

--- a/scripts/check-stale-events.js
+++ b/scripts/check-stale-events.js
@@ -26,6 +26,13 @@ const MAX_FUTURE_DAYS = 180;      // Skip events more than ~6 months out — Mee
                                   // typically only carry near-term events, so distant events
                                   // naturally fall off the feed without being cancelled.
 
+// Meetup RSS feeds are truncated by item count (currently 10 per group), not by date.
+// A group with a busy schedule therefore drops still-valid near-term events off the end
+// of its feed, which MAX_FUTURE_DAYS cannot catch. Absence from the feed is only a hint,
+// so before filing an issue we ask the source directly: Meetup serves a hard 404 for
+// deleted events and 200 for live ones.
+const DELETED_STATUS_CODES = new Set([404, 410]);
+
 /**
  * Makes an HTTPS request
  * @param {string} url - The URL to request
@@ -61,6 +68,49 @@ function makeRequest(url, options = {}, data = null) {
     }
     
     req.end();
+  });
+}
+
+/**
+ * Asks the source whether an event has actually been deleted.
+ * Errors and unexpected statuses resolve to false so that a flaky network or a
+ * Meetup layout change results in a missed issue rather than a false accusation.
+ * @param {string} url - The event URL to check
+ * @returns {Promise<boolean>} - True only if the source confirms the event is gone
+ */
+function isEventDeleted(url) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value) => {
+      if (!settled) {
+        settled = true;
+        resolve(value);
+      }
+    };
+
+    try {
+      const req = https.request(
+        url,
+        {
+          method: 'HEAD',
+          headers: { 'User-Agent': '757-community-site' },
+          timeout: 10000,
+        },
+        (res) => {
+          res.resume();
+          finish(DELETED_STATUS_CODES.has(res.statusCode));
+        }
+      );
+
+      req.on('timeout', () => {
+        req.destroy();
+        finish(false);
+      });
+      req.on('error', () => finish(false));
+      req.end();
+    } catch {
+      finish(false);
+    }
   });
 }
 
@@ -132,10 +182,10 @@ ${event.description ? event.description.substring(0, 500) + (event.description.l
 
 ---
 
-**This event hasn't been updated in the last ${STALE_THRESHOLD_HOURS} hours, suggesting it may have been cancelled or deleted from the source.**
+**This event hasn't been updated in the last ${STALE_THRESHOLD_HOURS} hours, and the source returned "not found" when asked for it directly — it appears to have been cancelled or deleted.**
 
 ### Action Required
-- [ ] Check if the event still exists at the source
+- [ ] Confirm the event is gone at the source
 - [ ] If cancelled/deleted, remove it from \`src/data/calendar-events.json\`
 - [ ] If still valid, investigate why it's not being updated
 
@@ -259,6 +309,34 @@ async function checkStaleEvents() {
       return;
     }
 
+    // Falling out of the RSS feed is only a hint. Confirm each candidate against the
+    // source so that events truncated off the end of a busy feed aren't reported as
+    // cancelled. Events with no link can't be confirmed, so they pass through.
+    console.log(`Confirming ${dedupedStaleEvents.length} stale candidates against the source...`);
+    const confirmedStaleEvents = [];
+    for (const event of dedupedStaleEvents) {
+      if (!event.link) {
+        console.log(`❓ ${event.title} - no link to verify, flagging for review`);
+        confirmedStaleEvents.push(event);
+        continue;
+      }
+
+      if (await isEventDeleted(event.link)) {
+        console.log(`🗑️ ${event.title} - confirmed deleted at source`);
+        confirmedStaleEvents.push(event);
+      } else {
+        console.log(`✅ ${event.title} - still live at source, not stale (likely truncated off the RSS feed)`);
+      }
+
+      // Be polite to Meetup between checks
+      await new Promise(resolve => setTimeout(resolve, 500));
+    }
+
+    if (confirmedStaleEvents.length === 0) {
+      console.log('No stale events confirmed at the source, no issues to create');
+      return;
+    }
+
     // Get existing issues to avoid duplicates across runs
     const existingIssues = await getExistingIssues();
     const existingEventTitles = new Set(
@@ -269,7 +347,7 @@ async function checkStaleEvents() {
 
     // Create issues for stale events that don't already have issues
     let issuesCreated = 0;
-    for (const event of dedupedStaleEvents) {
+    for (const event of confirmedStaleEvents) {
       if (!existingEventTitles.has(event.title)) {
         const issue = await createStaleEventIssue(event);
         if (issue) {
@@ -277,7 +355,7 @@ async function checkStaleEvents() {
         }
 
         // Rate limiting - wait 1 second between issue creation
-        if (issuesCreated < dedupedStaleEvents.length) {
+        if (issuesCreated < confirmedStaleEvents.length) {
           await new Promise(resolve => setTimeout(resolve, 1000));
         }
       } else {

--- a/scripts/deduplicate-calendar.js
+++ b/scripts/deduplicate-calendar.js
@@ -30,19 +30,32 @@ const CALENDAR_FILE_PATH = path.join(
 // most-recently-updated entry.
 const CROSS_POST_PREFERRED_GROUPS = ["757 Developers", "AI Collective Hampton Roads"];
 
+// Prefixes that groups put in front of a cross-posted title ("AICHR | Real Title").
+// Deliberately an explicit list rather than a generic "strip anything before a pipe":
+// a generic rule would also clip legitimate titles like "C++ | Intro to Templates",
+// and two such titles at the same start time would then be silently merged — dropping
+// a real event from the site. If a new group starts cross-posting, add its tag here.
+// Until then the worst case is a visible duplicate, which is far easier to notice than
+// a silently missing event.
+const CROSS_POST_TITLE_TAGS = ["AICHR"];
+
+const CROSS_POST_TAG_PATTERN = new RegExp(
+	`^(?:${CROSS_POST_TITLE_TAGS.map((tag) => tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})\\s*\\|\\s*`,
+	"i",
+);
+
 /**
  * Normalizes a title so the same event announced by two groups compares equal.
- * Strips decorative emoji and a short leading group tag ("AICHR | ..."), then
+ * Strips decorative emoji and a known leading group tag ("AICHR | ..."), then
  * lowercases and collapses whitespace.
  * @param {string} title
  * @returns {string}
  */
 function normalizeTitle(title) {
 	return (title || "")
-		.replace(/\p{Extended_Pictographic}/gu, "")
-		.replace(/[‍️]/g, "")
+		.replace(/[\p{Extended_Pictographic}\u{FE0F}\u{200D}]/gu, "")
 		.trim()
-		.replace(/^[^|]{1,16}\|\s*/, "")
+		.replace(CROSS_POST_TAG_PATTERN, "")
 		.toLowerCase()
 		.replace(/\s+/g, " ")
 		.trim();

--- a/scripts/deduplicate-calendar.js
+++ b/scripts/deduplicate-calendar.js
@@ -2,6 +2,10 @@
  * Script to deduplicate the calendar events
  * This script reads the calendar-events.json file, removes duplicate events
  * that have the same title, group, and date (ignoring time), and saves the result.
+ *
+ * It also collapses cross-posted events: a single real-world event announced by two
+ * Meetup groups arrives as two entries with different URLs, so the URL key alone can
+ * never catch them. See CROSS_POST_PREFERRED_GROUPS below.
  */
 
 import fs from "fs";
@@ -20,6 +24,58 @@ const CALENDAR_FILE_PATH = path.join(
 	"data",
 	"calendar-events.json",
 );
+
+// When the same event is cross-posted by multiple groups, the listing from the group
+// earliest in this list wins. Groups not named here rank last and fall back to the
+// most-recently-updated entry.
+const CROSS_POST_PREFERRED_GROUPS = ["757 Developers", "AI Collective Hampton Roads"];
+
+/**
+ * Normalizes a title so the same event announced by two groups compares equal.
+ * Strips decorative emoji and a short leading group tag ("AICHR | ..."), then
+ * lowercases and collapses whitespace.
+ * @param {string} title
+ * @returns {string}
+ */
+function normalizeTitle(title) {
+	return (title || "")
+		.replace(/\p{Extended_Pictographic}/gu, "")
+		.replace(/[‍️]/g, "")
+		.trim()
+		.replace(/^[^|]{1,16}\|\s*/, "")
+		.toLowerCase()
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+/**
+ * Ranks an event's group against CROSS_POST_PREFERRED_GROUPS. Lower wins.
+ * @param {Object} event
+ * @returns {number}
+ */
+function groupRank(event) {
+	const index = CROSS_POST_PREFERRED_GROUPS.indexOf(event.group);
+	return index === -1 ? CROSS_POST_PREFERRED_GROUPS.length : index;
+}
+
+/**
+ * Decides which of two cross-posted copies to keep: preferred group first, then
+ * whichever carries the freshest data from the source.
+ * @param {Object} incoming
+ * @param {Object} existing
+ * @returns {boolean} - True if incoming should replace existing
+ */
+function incomingWinsCrossPost(incoming, existing) {
+	const incomingRank = groupRank(incoming);
+	const existingRank = groupRank(existing);
+	if (incomingRank !== existingRank) {
+		return incomingRank < existingRank;
+	}
+	return (
+		new Date(incoming.updatedDate || incoming.date) >
+		new Date(existing.updatedDate || existing.date)
+	);
+}
 
 console.log("Starting calendar deduplication process...");
 
@@ -87,7 +143,37 @@ try {
 	}
 
 	// Convert map back to array
-	const dedupedEvents = Array.from(uniqueEventsMap.values());
+	const urlDedupedEvents = Array.from(uniqueEventsMap.values());
+
+	// Second pass: collapse cross-posted events. The same real-world event announced by
+	// two groups has two distinct URLs, so the primary key above can never match them.
+	// Keying on normalized title + exact start time catches the cross-post while staying
+	// strict enough that two genuinely different events don't get merged.
+	const crossPostMap = new Map();
+	const passThrough = [];
+	const crossPostsFound = [];
+
+	for (const event of urlDedupedEvents) {
+		if (event.source !== "meetup" || !event.date) {
+			passThrough.push(event);
+			continue;
+		}
+
+		const key = `${normalizeTitle(event.title)}|${new Date(event.date).toISOString()}`;
+		const existing = crossPostMap.get(key);
+
+		if (!existing) {
+			crossPostMap.set(key, event);
+			continue;
+		}
+
+		const winner = incomingWinsCrossPost(event, existing) ? event : existing;
+		const loser = winner === event ? existing : event;
+		crossPostsFound.push({ key, keptGroup: winner.group, droppedGroup: loser.group });
+		crossPostMap.set(key, winner);
+	}
+
+	const dedupedEvents = [...passThrough, ...crossPostMap.values()];
 
 	// Sort events by date
 	dedupedEvents.sort((a, b) => new Date(a.date) - new Date(b.date));
@@ -95,6 +181,17 @@ try {
 	// Log results
 	const removedCount = events.length - dedupedEvents.length;
 	console.log(`Found and removed ${removedCount} duplicate events`);
+
+	if (crossPostsFound.length > 0) {
+		console.log(
+			`Collapsed ${crossPostsFound.length} cross-posted events (preferring ${CROSS_POST_PREFERRED_GROUPS[0]}):`,
+		);
+		for (const cross of crossPostsFound) {
+			console.log(
+				`  "${cross.key}" - kept ${cross.keptGroup}, dropped ${cross.droppedGroup}`,
+			);
+		}
+	}
 
 	// Log the duplicates that were found
 	if (duplicatesFound.length > 0) {

--- a/scripts/fetch-meetup-images.js
+++ b/scripts/fetch-meetup-images.js
@@ -35,6 +35,13 @@ if (!fs.existsSync(meetupsImagesDir)) {
 const meetupsData = JSON.parse(fs.readFileSync(path.join(dataDir, 'meetups-combined.json'), 'utf8'));
 console.log(chalk.blue(`Loaded ${meetupsData.length} meetups from data file`));
 
+// Meetup group names carry decorative emoji that we don't want in the site's own
+// copy of the title. og:title reflects whatever the organizer set, so without this
+// every build re-introduces them.
+function stripEmoji(text) {
+  return text.replace(/[\p{Extended_Pictographic}\u{FE0F}\u{200D}]/gu, '').replace(/\s{2,}/g, ' ').trim();
+}
+
 // Function to extract Open Graph metadata from a URL
 async function fetchOgMetadata(url) {
   try {
@@ -50,7 +57,7 @@ async function fetchOgMetadata(url) {
     const metadata = {
       url,
       imageUrl: ogImage ? ogImage[1] : null,
-      title: ogTitle ? ogTitle[1] : null,
+      title: ogTitle ? stripEmoji(ogTitle[1]) : null,
       description: ogDescription ? ogDescription[1] : null
     };
     
@@ -238,7 +245,7 @@ async function processMeetups() {
   }
   
   // Save updated meetups data to file
-  fs.writeFileSync(meetupsOutputPath, JSON.stringify(meetupsData, null, 2));
+  fs.writeFileSync(meetupsOutputPath, `${JSON.stringify(meetupsData, null, 2)}\n`);
   console.log(chalk.green(`Saved updated meetups data to ${meetupsOutputPath}`));
   console.log(chalk.green(`Successfully processed ${successCount} meetups`));
   

--- a/src/data/calendar-events.json
+++ b/src/data/calendar-events.json
@@ -81,17 +81,6 @@
     "updatedDate": "2026-07-15T18:26:26.788Z"
   },
   {
-    "title": "🧜‍♀️ AICHR | Peninsula Builders Study Group",
-    "link": "https://www.meetup.com/aicollectivehr/events/315505827/",
-    "date": "2026-07-21T22:00:00.000Z",
-    "description": "New AI tools are dropping every week. Bookmarks are piling up. “To-be-studied” lists are growing faster than we can keep up with.\n\nSound familiar?\n\nPeninsula Builders Study Group is a local initiative for students and developers of the Peninsula area who want to stop *meaning to learn* and start actually doing it—together.\n\nThere’s no pressure to be an expert, and no bootcamp intensity. Just a consistent habit, a room full of curious people, and the accountability that comes from showing up.\n\n**Things to bring:**\n\n* Laptop\n\n**Session details:**\n🕕 Time: 6:00 PM – 7:30 PM\n📍 Location: Christopher Newport University (Luter 170)\n🔁 Frequency: Bi-weekly (Tuesdays)\n\n**Stay connected:**\nJoin Slack: https://docs.google.com/forms/d/e/1FAIpQLSflVL1WYj3NpiSZ2o7QjJW17-HojU3wPyeeQVIWhKI_4OtFPQ/viewform?usp=dialog\n\n**🤝 Organizers & partners**\n**​**\n**Organizers**\n[The AI Collective Hampton Roads](https://linktr.ee/aicollectivehr)\n\n**​Platinum partners**\n[TechArk](https://gotechark.com/)\n[Regent University](https://www.regent.edu/)\n[ECPI University](https://www.ecpi.edu/)\n[Hampton Roads Chamber Foundation](https://hrchamber.com/)\n[Retail Alliance](https://retailalliance.com/) & [Retail Alliance Foundation](https://retailalliance.com/about-us/foundation/programs/)\n[The HIVE + City of Virginia Beach](https://yesvirginiabeach.com/the-hive)\n\n**Bronze partners**\n[Assembly](https://www.assemblynfk.com/)\n[757 Collab](https://757collab.org/)\n\n**🌍 ​Our parent org**\n\n[The AI Collective](https://www.aicollective.com/) is a global non-profit community uniting 200,000+ pioneers – founders, researchers, operators, and investors – exploring the frontier of AI in major tech hubs worldwide. Through events, workshops, and community-led research, we empower the AI ecosystem to collaboratively steer AI’s future toward trust, openness, and human flourishing.\n\nAll attendees and organizers at events affiliated with The AI Collective agree to our[ privacy policy](https://www.aicollective.com/files/Data%20Privacy%20and%20Use%20Policy%20~%20The%20AI%20Collective.pdf) and are subject to our[ code of conduct](https://www.aicollective.com/files/Code%20of%20Conduct%20~%20The%20AI%20Collective.pdf). Additionally, by registering for this event, you agree to The AI Collective Hampton Roads chapter[ photo & video policy](https://sites.google.com/view/aicollectivehr/policies/photo-video).",
-    "source": "meetup",
-    "group": "AI Collective Hampton Roads",
-    "featuredEvent": false,
-    "createdDate": "2026-07-02T00:45:25.795Z",
-    "updatedDate": "2026-07-15T18:26:26.788Z"
-  },
-  {
     "title": "Peninsula Builders Study Group",
     "link": "https://www.meetup.com/757dev/events/315274975/",
     "date": "2026-07-21T22:00:00.000Z",
@@ -177,17 +166,6 @@
     "updatedDate": "2026-07-15T18:26:05.064Z"
   },
   {
-    "title": "🧜‍♀️ AICHR | Peninsula Builders Study Group",
-    "link": "https://www.meetup.com/aicollectivehr/events/wbxfztyjclbgb/",
-    "date": "2026-08-04T22:00:00.000Z",
-    "description": "New AI tools are dropping every week. Bookmarks are piling up. “To-be-studied” lists are growing faster than we can keep up with.\n\nSound familiar?\n\nPeninsula Builders Study Group is a local initiative for students and developers of the Peninsula area who want to stop *meaning to learn* and start actually doing it—together.\n\nThere’s no pressure to be an expert, and no bootcamp intensity. Just a consistent habit, a room full of curious people, and the accountability that comes from showing up.\n\n**Things to bring:**\n\n* Laptop\n\n**Session details:**\n🕕 Time: 6:00 PM – 7:30 PM\n📍 Location: Christopher Newport University (Luter 170)\n🔁 Frequency: Bi-weekly (Tuesdays)\n\n**Stay connected:**\nJoin Slack: https://docs.google.com/forms/d/e/1FAIpQLSflVL1WYj3NpiSZ2o7QjJW17-HojU3wPyeeQVIWhKI_4OtFPQ/viewform?usp=dialog\n\n**🤝 Organizers & partners**\n**​**\n**Organizers**\n[The AI Collective Hampton Roads](https://linktr.ee/aicollectivehr)\n\n**​Platinum partners**\n[TechArk](https://gotechark.com/)\n[Regent University](https://www.regent.edu/)\n[ECPI University](https://www.ecpi.edu/)\n[Hampton Roads Chamber Foundation](https://hrchamber.com/)\n[Retail Alliance](https://retailalliance.com/) & [Retail Alliance Foundation](https://retailalliance.com/about-us/foundation/programs/)\n[The HIVE + City of Virginia Beach](https://yesvirginiabeach.com/the-hive)\n\n**Bronze partners**\n[Assembly](https://www.assemblynfk.com/)\n[757 Collab](https://757collab.org/)\n\n**🌍 ​Our parent org**\n\n[The AI Collective](https://www.aicollective.com/) is a global non-profit community uniting 200,000+ pioneers – founders, researchers, operators, and investors – exploring the frontier of AI in major tech hubs worldwide. Through events, workshops, and community-led research, we empower the AI ecosystem to collaboratively steer AI’s future toward trust, openness, and human flourishing.\n\nAll attendees and organizers at events affiliated with The AI Collective agree to our[ privacy policy](https://www.aicollective.com/files/Data%20Privacy%20and%20Use%20Policy%20~%20The%20AI%20Collective.pdf) and are subject to our[ code of conduct](https://www.aicollective.com/files/Code%20of%20Conduct%20~%20The%20AI%20Collective.pdf). Additionally, by registering for this event, you agree to The AI Collective Hampton Roads chapter[ photo & video policy](https://sites.google.com/view/aicollectivehr/policies/photo-video).",
-    "source": "meetup",
-    "group": "AI Collective Hampton Roads",
-    "featuredEvent": false,
-    "createdDate": "2026-07-06T18:39:07.474Z",
-    "updatedDate": "2026-07-15T18:26:26.788Z"
-  },
-  {
     "title": "Peninsula Builders Study Group",
     "link": "https://www.meetup.com/757dev/events/315666397/",
     "date": "2026-08-04T22:00:00.000Z",
@@ -240,17 +218,6 @@
     "group": "Information Systems Security Association ISSA Hampton Roads",
     "featuredEvent": false,
     "createdDate": "2026-05-06T00:36:42.336Z",
-    "updatedDate": "2026-07-15T18:26:26.788Z"
-  },
-  {
-    "title": "🧜‍♀️ AICHR | Peninsula Builders Study Group",
-    "link": "https://www.meetup.com/aicollectivehr/events/wbxfztyjclbxb/",
-    "date": "2026-08-18T22:00:00.000Z",
-    "description": "New AI tools are dropping every week. Bookmarks are piling up. “To-be-studied” lists are growing faster than we can keep up with.\n\nSound familiar?\n\nPeninsula Builders Study Group is a local initiative for students and developers of the Peninsula area who want to stop *meaning to learn* and start actually doing it—together.\n\nThere’s no pressure to be an expert, and no bootcamp intensity. Just a consistent habit, a room full of curious people, and the accountability that comes from showing up.\n\n**Things to bring:**\n\n* Laptop\n\n**Session details:**\n🕕 Time: 6:00 PM – 7:30 PM\n📍 Location: Christopher Newport University (Luter 170)\n🔁 Frequency: Bi-weekly (Tuesdays)\n\n**Stay connected:**\nJoin Slack: https://docs.google.com/forms/d/e/1FAIpQLSflVL1WYj3NpiSZ2o7QjJW17-HojU3wPyeeQVIWhKI_4OtFPQ/viewform?usp=dialog\n\n**🤝 Organizers & partners**\n**​**\n**Organizers**\n[The AI Collective Hampton Roads](https://linktr.ee/aicollectivehr)\n\n**​Platinum partners**\n[TechArk](https://gotechark.com/)\n[Regent University](https://www.regent.edu/)\n[ECPI University](https://www.ecpi.edu/)\n[Hampton Roads Chamber Foundation](https://hrchamber.com/)\n[Retail Alliance](https://retailalliance.com/) & [Retail Alliance Foundation](https://retailalliance.com/about-us/foundation/programs/)\n[The HIVE + City of Virginia Beach](https://yesvirginiabeach.com/the-hive)\n\n**Bronze partners**\n[Assembly](https://www.assemblynfk.com/)\n[757 Collab](https://757collab.org/)\n\n**🌍 ​Our parent org**\n\n[The AI Collective](https://www.aicollective.com/) is a global non-profit community uniting 200,000+ pioneers – founders, researchers, operators, and investors – exploring the frontier of AI in major tech hubs worldwide. Through events, workshops, and community-led research, we empower the AI ecosystem to collaboratively steer AI’s future toward trust, openness, and human flourishing.\n\nAll attendees and organizers at events affiliated with The AI Collective agree to our[ privacy policy](https://www.aicollective.com/files/Data%20Privacy%20and%20Use%20Policy%20~%20The%20AI%20Collective.pdf) and are subject to our[ code of conduct](https://www.aicollective.com/files/Code%20of%20Conduct%20~%20The%20AI%20Collective.pdf). Additionally, by registering for this event, you agree to The AI Collective Hampton Roads chapter[ photo & video policy](https://sites.google.com/view/aicollectivehr/policies/photo-video).",
-    "source": "meetup",
-    "group": "AI Collective Hampton Roads",
-    "featuredEvent": false,
-    "createdDate": "2026-07-06T18:39:08.515Z",
     "updatedDate": "2026-07-15T18:26:26.788Z"
   },
   {
@@ -313,17 +280,6 @@
     "updatedDate": "2026-07-15T18:26:26.788Z"
   },
   {
-    "title": "🧜‍♀️ AICHR | Peninsula Builders Study Group",
-    "link": "https://www.meetup.com/aicollectivehr/events/wbxfztyjcmbcb/",
-    "date": "2026-09-01T22:00:00.000Z",
-    "description": "New AI tools are dropping every week. Bookmarks are piling up. “To-be-studied” lists are growing faster than we can keep up with.\n\nSound familiar?\n\nPeninsula Builders Study Group is a local initiative for students and developers of the Peninsula area who want to stop *meaning to learn* and start actually doing it—together.\n\nThere’s no pressure to be an expert, and no bootcamp intensity. Just a consistent habit, a room full of curious people, and the accountability that comes from showing up.\n\n**Things to bring:**\n\n* Laptop\n\n**Session details:**\n🕕 Time: 6:00 PM – 7:30 PM\n📍 Location: Christopher Newport University (Luter 170)\n🔁 Frequency: Bi-weekly (Tuesdays)\n\n**Stay connected:**\nJoin Slack: https://docs.google.com/forms/d/e/1FAIpQLSflVL1WYj3NpiSZ2o7QjJW17-HojU3wPyeeQVIWhKI_4OtFPQ/viewform?usp=dialog\n\n**🤝 Organizers & partners**\n**​**\n**Organizers**\n[The AI Collective Hampton Roads](https://linktr.ee/aicollectivehr)\n\n**​Platinum partners**\n[TechArk](https://gotechark.com/)\n[Regent University](https://www.regent.edu/)\n[ECPI University](https://www.ecpi.edu/)\n[Hampton Roads Chamber Foundation](https://hrchamber.com/)\n[Retail Alliance](https://retailalliance.com/) & [Retail Alliance Foundation](https://retailalliance.com/about-us/foundation/programs/)\n[The HIVE + City of Virginia Beach](https://yesvirginiabeach.com/the-hive)\n\n**Bronze partners**\n[Assembly](https://www.assemblynfk.com/)\n[757 Collab](https://757collab.org/)\n\n**🌍 ​Our parent org**\n\n[The AI Collective](https://www.aicollective.com/) is a global non-profit community uniting 200,000+ pioneers – founders, researchers, operators, and investors – exploring the frontier of AI in major tech hubs worldwide. Through events, workshops, and community-led research, we empower the AI ecosystem to collaboratively steer AI’s future toward trust, openness, and human flourishing.\n\nAll attendees and organizers at events affiliated with The AI Collective agree to our[ privacy policy](https://www.aicollective.com/files/Data%20Privacy%20and%20Use%20Policy%20~%20The%20AI%20Collective.pdf) and are subject to our[ code of conduct](https://www.aicollective.com/files/Code%20of%20Conduct%20~%20The%20AI%20Collective.pdf). Additionally, by registering for this event, you agree to The AI Collective Hampton Roads chapter[ photo & video policy](https://sites.google.com/view/aicollectivehr/policies/photo-video).",
-    "source": "meetup",
-    "group": "AI Collective Hampton Roads",
-    "featuredEvent": false,
-    "createdDate": "2026-07-06T18:39:09.906Z",
-    "updatedDate": "2026-07-15T18:26:26.788Z"
-  },
-  {
     "title": "Peninsula Builders Study Group",
     "link": "https://www.meetup.com/757dev/events/tbxfztyjcmbcb/",
     "date": "2026-09-01T22:00:00.000Z",
@@ -354,17 +310,6 @@
     "group": "Information Systems Security Association ISSA Hampton Roads",
     "featuredEvent": false,
     "createdDate": "2026-05-28T00:41:21.530Z",
-    "updatedDate": "2026-07-15T18:26:26.788Z"
-  },
-  {
-    "title": "🧜‍♀️ AICHR | Peninsula Builders Study Group",
-    "link": "https://www.meetup.com/aicollectivehr/events/wbxfztyjcmbtb/",
-    "date": "2026-09-15T22:00:00.000Z",
-    "description": "New AI tools are dropping every week. Bookmarks are piling up. “To-be-studied” lists are growing faster than we can keep up with.\n\nSound familiar?\n\nPeninsula Builders Study Group is a local initiative for students and developers of the Peninsula area who want to stop *meaning to learn* and start actually doing it—together.\n\nThere’s no pressure to be an expert, and no bootcamp intensity. Just a consistent habit, a room full of curious people, and the accountability that comes from showing up.\n\n**Things to bring:**\n\n* Laptop\n\n**Session details:**\n🕕 Time: 6:00 PM – 7:30 PM\n📍 Location: Christopher Newport University (Luter 170)\n🔁 Frequency: Bi-weekly (Tuesdays)\n\n**Stay connected:**\nJoin Slack: https://docs.google.com/forms/d/e/1FAIpQLSflVL1WYj3NpiSZ2o7QjJW17-HojU3wPyeeQVIWhKI_4OtFPQ/viewform?usp=dialog\n\n**🤝 Organizers & partners**\n**​**\n**Organizers**\n[The AI Collective Hampton Roads](https://linktr.ee/aicollectivehr)\n\n**​Platinum partners**\n[TechArk](https://gotechark.com/)\n[Regent University](https://www.regent.edu/)\n[ECPI University](https://www.ecpi.edu/)\n[Hampton Roads Chamber Foundation](https://hrchamber.com/)\n[Retail Alliance](https://retailalliance.com/) & [Retail Alliance Foundation](https://retailalliance.com/about-us/foundation/programs/)\n[The HIVE + City of Virginia Beach](https://yesvirginiabeach.com/the-hive)\n\n**Bronze partners**\n[Assembly](https://www.assemblynfk.com/)\n[757 Collab](https://757collab.org/)\n\n**🌍 ​Our parent org**\n\n[The AI Collective](https://www.aicollective.com/) is a global non-profit community uniting 200,000+ pioneers – founders, researchers, operators, and investors – exploring the frontier of AI in major tech hubs worldwide. Through events, workshops, and community-led research, we empower the AI ecosystem to collaboratively steer AI’s future toward trust, openness, and human flourishing.\n\nAll attendees and organizers at events affiliated with The AI Collective agree to our[ privacy policy](https://www.aicollective.com/files/Data%20Privacy%20and%20Use%20Policy%20~%20The%20AI%20Collective.pdf) and are subject to our[ code of conduct](https://www.aicollective.com/files/Code%20of%20Conduct%20~%20The%20AI%20Collective.pdf). Additionally, by registering for this event, you agree to The AI Collective Hampton Roads chapter[ photo & video policy](https://sites.google.com/view/aicollectivehr/policies/photo-video).",
-    "source": "meetup",
-    "group": "AI Collective Hampton Roads",
-    "featuredEvent": false,
-    "createdDate": "2026-07-06T18:39:10.488Z",
     "updatedDate": "2026-07-15T18:26:26.788Z"
   },
   {
@@ -436,17 +381,6 @@
     "group": "AI Collective Hampton Roads",
     "featuredEvent": false,
     "createdDate": "2026-06-24T00:41:36.905Z",
-    "updatedDate": "2026-07-15T18:26:26.788Z"
-  },
-  {
-    "title": "🧜‍♀️ AICHR | Peninsula Builders Study Group",
-    "link": "https://www.meetup.com/aicollectivehr/events/wbxfztyjcmbmc/",
-    "date": "2026-09-29T22:00:00.000Z",
-    "description": "New AI tools are dropping every week. Bookmarks are piling up. “To-be-studied” lists are growing faster than we can keep up with.\n\nSound familiar?\n\nPeninsula Builders Study Group is a local initiative for students and developers of the Peninsula area who want to stop *meaning to learn* and start actually doing it—together.\n\nThere’s no pressure to be an expert, and no bootcamp intensity. Just a consistent habit, a room full of curious people, and the accountability that comes from showing up.\n\n**Things to bring:**\n\n* Laptop\n\n**Session details:**\n🕕 Time: 6:00 PM – 7:30 PM\n📍 Location: Christopher Newport University (Luter 170)\n🔁 Frequency: Bi-weekly (Tuesdays)\n\n**Stay connected:**\nJoin Slack: https://docs.google.com/forms/d/e/1FAIpQLSflVL1WYj3NpiSZ2o7QjJW17-HojU3wPyeeQVIWhKI_4OtFPQ/viewform?usp=dialog\n\n**🤝 Organizers & partners**\n**​**\n**Organizers**\n[The AI Collective Hampton Roads](https://linktr.ee/aicollectivehr)\n\n**​Platinum partners**\n[TechArk](https://gotechark.com/)\n[Regent University](https://www.regent.edu/)\n[ECPI University](https://www.ecpi.edu/)\n[Hampton Roads Chamber Foundation](https://hrchamber.com/)\n[Retail Alliance](https://retailalliance.com/) & [Retail Alliance Foundation](https://retailalliance.com/about-us/foundation/programs/)\n[The HIVE + City of Virginia Beach](https://yesvirginiabeach.com/the-hive)\n\n**Bronze partners**\n[Assembly](https://www.assemblynfk.com/)\n[757 Collab](https://757collab.org/)\n\n**🌍 ​Our parent org**\n\n[The AI Collective](https://www.aicollective.com/) is a global non-profit community uniting 200,000+ pioneers – founders, researchers, operators, and investors – exploring the frontier of AI in major tech hubs worldwide. Through events, workshops, and community-led research, we empower the AI ecosystem to collaboratively steer AI’s future toward trust, openness, and human flourishing.\n\nAll attendees and organizers at events affiliated with The AI Collective agree to our[ privacy policy](https://www.aicollective.com/files/Data%20Privacy%20and%20Use%20Policy%20~%20The%20AI%20Collective.pdf) and are subject to our[ code of conduct](https://www.aicollective.com/files/Code%20of%20Conduct%20~%20The%20AI%20Collective.pdf). Additionally, by registering for this event, you agree to The AI Collective Hampton Roads chapter[ photo & video policy](https://sites.google.com/view/aicollectivehr/policies/photo-video).",
-    "source": "meetup",
-    "group": "AI Collective Hampton Roads",
-    "featuredEvent": false,
-    "createdDate": "2026-07-06T18:39:12.510Z",
     "updatedDate": "2026-07-15T18:26:26.788Z"
   },
   {

--- a/src/data/calendar-events.json
+++ b/src/data/calendar-events.json
@@ -177,17 +177,6 @@
     "updatedDate": "2026-07-15T18:26:05.064Z"
   },
   {
-    "title": "Peninsula Developers Study Group",
-    "link": "https://www.meetup.com/757dev/events/qtrcztyjclbgb/",
-    "date": "2026-08-04T22:00:00.000Z",
-    "description": "New AI tools are dropping every week. Bookmarks are piling up. “To-be-studied” lists are growing faster than we can keep up with.\n\nSound familiar?\n\nPeninsula Builders Study Group is a local initiative for students and developers of the Peninsula area who want to stop *meaning to learn* and start actually doing it—together.\n\nThere’s no pressure to be an expert, and no bootcamp intensity. Just a consistent habit, a room full of curious people, and the accountability that comes from showing up.\n\n**How it works:**\nWe meet every two weeks on Tuesdays from 6:00–7:30 PM at CNU.\n\n**Things to bring:**\n\n* Laptop\n\n**Session details:**\n🕕 Time: 6:00 PM – 7:30 PM\n📍 Location: Christopher Newport University (Luter 170)\n🔁 Frequency: Bi-weekly (Tuesdays)\n\n**Directions:**\nPark in the visitor spots in front of Trible Library. From there, take the first right onto the brick path (on your right if you’re facing the library), walk past the Freeman Center, and take the first left. Luter 170 is in the rightmost wing of the Luter Hall building, you’ll see a sign on the door.",
-    "source": "meetup",
-    "group": "757 Developers",
-    "featuredEvent": false,
-    "createdDate": "2026-06-28T18:26:19.148Z",
-    "updatedDate": "2026-07-06T13:17:48.953Z"
-  },
-  {
     "title": "🧜‍♀️ AICHR | Peninsula Builders Study Group",
     "link": "https://www.meetup.com/aicollectivehr/events/wbxfztyjclbgb/",
     "date": "2026-08-04T22:00:00.000Z",
@@ -252,17 +241,6 @@
     "featuredEvent": false,
     "createdDate": "2026-05-06T00:36:42.336Z",
     "updatedDate": "2026-07-15T18:26:26.788Z"
-  },
-  {
-    "title": "Peninsula Developers Study Group",
-    "link": "https://www.meetup.com/757dev/events/qtrcztyjclbxb/",
-    "date": "2026-08-18T22:00:00.000Z",
-    "description": "New AI tools are dropping every week. Bookmarks are piling up. “To-be-studied” lists are growing faster than we can keep up with.\n\nSound familiar?\n\nPeninsula Builders Study Group is a local initiative for students and developers of the Peninsula area who want to stop *meaning to learn* and start actually doing it—together.\n\nThere’s no pressure to be an expert, and no bootcamp intensity. Just a consistent habit, a room full of curious people, and the accountability that comes from showing up.\n\n**How it works:**\nWe meet every two weeks on Tuesdays from 6:00–7:30 PM at CNU.\n\n**Things to bring:**\n\n* Laptop\n\n**Session details:**\n🕕 Time: 6:00 PM – 7:30 PM\n📍 Location: Christopher Newport University (Luter 170)\n🔁 Frequency: Bi-weekly (Tuesdays)\n\n**Directions:**\nPark in the visitor spots in front of Trible Library. From there, take the first right onto the brick path (on your right if you’re facing the library), walk past the Freeman Center, and take the first left. Luter 170 is in the rightmost wing of the Luter Hall building, you’ll see a sign on the door.",
-    "source": "meetup",
-    "group": "757 Developers",
-    "featuredEvent": false,
-    "createdDate": "2026-06-28T18:26:23.753Z",
-    "updatedDate": "2026-07-06T13:17:48.953Z"
   },
   {
     "title": "🧜‍♀️ AICHR | Peninsula Builders Study Group",
@@ -335,17 +313,6 @@
     "updatedDate": "2026-07-15T18:26:26.788Z"
   },
   {
-    "title": "Peninsula Developers Study Group",
-    "link": "https://www.meetup.com/757dev/events/qtrcztyjcmbcb/",
-    "date": "2026-09-01T22:00:00.000Z",
-    "description": "New AI tools are dropping every week. Bookmarks are piling up. “To-be-studied” lists are growing faster than we can keep up with.\n\nSound familiar?\n\nPeninsula Builders Study Group is a local initiative for students and developers of the Peninsula area who want to stop *meaning to learn* and start actually doing it—together.\n\nThere’s no pressure to be an expert, and no bootcamp intensity. Just a consistent habit, a room full of curious people, and the accountability that comes from showing up.\n\n**How it works:**\nWe meet every two weeks on Tuesdays from 6:00–7:30 PM at CNU.\n\n**Things to bring:**\n\n* Laptop\n\n**Session details:**\n🕕 Time: 6:00 PM – 7:30 PM\n📍 Location: Christopher Newport University (Luter 170)\n🔁 Frequency: Bi-weekly (Tuesdays)\n\n**Directions:**\nPark in the visitor spots in front of Trible Library. From there, take the first right onto the brick path (on your right if you’re facing the library), walk past the Freeman Center, and take the first left. Luter 170 is in the rightmost wing of the Luter Hall building, you’ll see a sign on the door.",
-    "source": "meetup",
-    "group": "757 Developers",
-    "featuredEvent": false,
-    "createdDate": "2026-06-28T18:26:24.531Z",
-    "updatedDate": "2026-07-06T13:17:48.953Z"
-  },
-  {
     "title": "🧜‍♀️ AICHR | Peninsula Builders Study Group",
     "link": "https://www.meetup.com/aicollectivehr/events/wbxfztyjcmbcb/",
     "date": "2026-09-01T22:00:00.000Z",
@@ -388,17 +355,6 @@
     "featuredEvent": false,
     "createdDate": "2026-05-28T00:41:21.530Z",
     "updatedDate": "2026-07-15T18:26:26.788Z"
-  },
-  {
-    "title": "Peninsula Developers Study Group",
-    "link": "https://www.meetup.com/757dev/events/qtrcztyjcmbtb/",
-    "date": "2026-09-15T22:00:00.000Z",
-    "description": "New AI tools are dropping every week. Bookmarks are piling up. “To-be-studied” lists are growing faster than we can keep up with.\n\nSound familiar?\n\nPeninsula Builders Study Group is a local initiative for students and developers of the Peninsula area who want to stop *meaning to learn* and start actually doing it—together.\n\nThere’s no pressure to be an expert, and no bootcamp intensity. Just a consistent habit, a room full of curious people, and the accountability that comes from showing up.\n\n**How it works:**\nWe meet every two weeks on Tuesdays from 6:00–7:30 PM at CNU.\n\n**Things to bring:**\n\n* Laptop\n\n**Session details:**\n🕕 Time: 6:00 PM – 7:30 PM\n📍 Location: Christopher Newport University (Luter 170)\n🔁 Frequency: Bi-weekly (Tuesdays)\n\n**Directions:**\nPark in the visitor spots in front of Trible Library. From there, take the first right onto the brick path (on your right if you’re facing the library), walk past the Freeman Center, and take the first left. Luter 170 is in the rightmost wing of the Luter Hall building, you’ll see a sign on the door.",
-    "source": "meetup",
-    "group": "757 Developers",
-    "featuredEvent": false,
-    "createdDate": "2026-06-28T18:26:26.542Z",
-    "updatedDate": "2026-07-06T13:17:48.953Z"
   },
   {
     "title": "🧜‍♀️ AICHR | Peninsula Builders Study Group",
@@ -481,17 +437,6 @@
     "featuredEvent": false,
     "createdDate": "2026-06-24T00:41:36.905Z",
     "updatedDate": "2026-07-15T18:26:26.788Z"
-  },
-  {
-    "title": "Peninsula Developers Study Group",
-    "link": "https://www.meetup.com/757dev/events/qtrcztyjcmbmc/",
-    "date": "2026-09-29T22:00:00.000Z",
-    "description": "New AI tools are dropping every week. Bookmarks are piling up. “To-be-studied” lists are growing faster than we can keep up with.\n\nSound familiar?\n\nPeninsula Builders Study Group is a local initiative for students and developers of the Peninsula area who want to stop *meaning to learn* and start actually doing it—together.\n\nThere’s no pressure to be an expert, and no bootcamp intensity. Just a consistent habit, a room full of curious people, and the accountability that comes from showing up.\n\n**How it works:**\nWe meet every two weeks on Tuesdays from 6:00–7:30 PM at CNU.\n\n**Things to bring:**\n\n* Laptop\n\n**Session details:**\n🕕 Time: 6:00 PM – 7:30 PM\n📍 Location: Christopher Newport University (Luter 170)\n🔁 Frequency: Bi-weekly (Tuesdays)\n\n**Directions:**\nPark in the visitor spots in front of Trible Library. From there, take the first right onto the brick path (on your right if you’re facing the library), walk past the Freeman Center, and take the first left. Luter 170 is in the rightmost wing of the Luter Hall building, you’ll see a sign on the door.",
-    "source": "meetup",
-    "group": "757 Developers",
-    "featuredEvent": false,
-    "createdDate": "2026-06-28T18:26:27.623Z",
-    "updatedDate": "2026-06-29T13:31:16.401Z"
   },
   {
     "title": "🧜‍♀️ AICHR | Peninsula Builders Study Group",


### PR DESCRIPTION
Closes #269, #270, #274.

Three open `stale-event` issues turned out to be one recurring study group flagged three different ways. Investigating them surfaced two real bugs in the calendar pipeline.

## 1. Stale detection filed issues for live events (#274)

Meetup's RSS feed is truncated by **item count** (10 per group), not by date. The furthest-out occurrence of a recurring series drops off the end of the feed, stops receiving `updatedDate` refreshes, and looks cancelled.

`MAX_FUTURE_DAYS = 180` was written for exactly this, but it's time-based while the truncation is count-based — the flagged 9/29 session is only ~76 days out, well inside the window, yet it's item #11 in a 10-item feed. The guard could never catch it.

Absence from the feed is now only a hint. Before filing, the checker asks the source directly: Meetup serves a hard 404 for deleted events and 200 for live ones. Network errors and unexpected statuses resolve to "not deleted", so a flaky check misses an issue rather than reporting a live event as cancelled.

## 2. Cross-posted events were double-listed (#269)

The Peninsula Builders Study Group is announced by **both** 757 Developers and AI Collective Hampton Roads — one real session, two Meetup listings. Dedupe keys meetup events on URL, and a cross-post has a different URL per group, so the copies could never collide. **Six dates were showing twice on the live site.**

Added a second pass keyed on normalized title + exact start time — strict enough not to merge genuinely distinct events. Normalizing strips decorative emoji and a short leading group tag so `🧜‍♀️ AICHR | Peninsula Builders Study Group` matches its 757dev twin. The preferred group wins; unlisted groups fall back to the freshest entry, so AICHR-only dates (10/13, 10/27) are **kept rather than dropped**.

## 3. Data cleanup (#270)

The whole `Peninsula Developers Study Group` series is genuinely gone — renamed to "Builders". All five occurrences confirmed 404 at the source and removed. The replacement series was already on the calendar, so no dates were lost.

Calendar: **56 → 45 events** (5 deleted + 6 cross-posts collapsed).

## Verification

- `isEventDeleted` checked against the real URLs: correctly separates the live event from the deleted ones, and fails safe on an unreachable host (5/5).
- Title normalization: collapses the cross-post, keeps distinct events apart, leaves untagged titles intact (5/5).
- Stale checker run end-to-end against live data — finds the #274 event, confirms it live, files nothing.
- `npm run deduplicate-calendar` is idempotent (0 removed on second run).
- `npm run validate` passes; `npm run build` succeeds (76 pages).
- Confirmed in the **built HTML**: only the two expected October AICHR dates render, all six cross-posts absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 4. Emoji kept coming back into group titles

`og:title` reflects whatever the organizer set as the Meetup group name, so **every build** re-introduced the decorative emoji into `metadata.title` — the 🧜‍♀️ in the AI Collective Hampton Roads title returned after being removed by hand. Stripped at the point it enters our data, reusing the same expression as `stripEmoji()` in `create-bento-broadcast.js`.

The script also wrote `meetups-combined.json` without the trailing newline the committed file has, so every build rewrote the last line and left the file dirty. Now writes it.

Verified: a full build re-fetches the live AICHR page and leaves the file **byte-identical** (16210 = 16210, `cmp` clean).
