### PR TITLE
Add social links + wire Submit/Add CTAs to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-your-group.yml
+++ b/.github/ISSUE_TEMPLATE/add-your-group.yml
@@ -1,0 +1,94 @@
+name: Add Your Group
+description: Add a meetup group or community to the 757 Tech Community site
+title: "[Group]: "
+labels:
+  - group
+  - needs-review
+  - group-submission
+assignees:
+  - 1kevgriff
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Thanks for adding your group!
+        Please fill out the information below to help us list your group on the 757 Tech Community site.
+
+        Once reviewed and approved, your group will appear on the site — and if you provide a Meetup RSS feed, your events will be pulled into the calendar automatically.
+
+  - type: input
+    id: group-name
+    attributes:
+      label: Group Name
+      description: The full name of the group
+      placeholder: "e.g., Hampton Roads .NET Users Group"
+    validations:
+      required: true
+
+  - type: input
+    id: group-url
+    attributes:
+      label: Group URL
+      description: Where people can find and join the group (Meetup.com, LinkedIn, or your own site)
+      placeholder: "https://www.meetup.com/your-group-name/"
+    validations:
+      required: true
+
+  - type: input
+    id: rss-feed
+    attributes:
+      label: Meetup RSS Feed
+      description: If the group is on Meetup.com, the events RSS feed URL — this lets us add your events to the calendar automatically
+      placeholder: "https://www.meetup.com/your-group-name/events/rss/"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: Which category fits the group best?
+      options:
+        - Development
+        - Technology
+        - Design
+        - Cloud
+    validations:
+      required: true
+
+  - type: input
+    id: tags
+    attributes:
+      label: Tags
+      description: A few comma-separated tags describing the group's focus
+      placeholder: "e.g., JavaScript, Web Development"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A short description of the group — who it's for and what you do
+      placeholder: "Tell the community what your group is about, how often you meet, and who should join."
+    validations:
+      required: true
+
+  - type: input
+    id: meeting-cadence
+    attributes:
+      label: Meeting Cadence & Location
+      description: When and where the group usually meets
+      placeholder: "e.g., Second Tuesday of every month at Assembly, Norfolk"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this group, you agree to follow our community guidelines
+      options:
+        - label: I agree to follow the 757 Tech Community Code of Conduct
+          required: true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 This repository contains the source code for the 757 Community website.
 
+## 🌊 Follow 757tech
+
+- **Website:** [757tech.org](https://757tech.org)
+- **LinkedIn:** [757tech](https://www.linkedin.com/company/757tech)
+- **X:** [@757techorg](https://x.com/757techorg)
+- **Instagram:** [@757techorg](https://www.instagram.com/757techorg/)
+- **Threads:** [@757techorg](https://www.threads.com/@757techorg)
+- **Slack:** [757dev workspace](https://join.slack.com/t/757dev/shared_invite/zt-37d031yip-yI9z3ez8ezf~mJTy5ICaeQ)
+- **Discord:** [Join the server](https://discord.gg/bPGsCKBqWp)
+
 ## 🧞 Commands
 
 All commands are run from the root of the project, from a terminal:

--- a/src/components/landing/LandingFooter.astro
+++ b/src/components/landing/LandingFooter.astro
@@ -3,6 +3,7 @@ import { COMMUNITY } from "../../data/community";
 const {
   slack: SLACK, discord: DISCORD, github: GITHUB,
   linkedin: LINKEDIN, x: X, instagram: INSTAGRAM, threads: THREADS,
+  submitEvent: SUBMIT_EVENT,
 } = COMMUNITY;
 
 // `subpage`: the anchor targets live on the landing page, so links get a
@@ -33,7 +34,7 @@ const year = new Date().getFullYear();
       </div>
       <div class="footer-col">
         <h4>Get involved</h4>
-        <a href={`${root}#submit`}>Submit an event</a>
+        <a href={SUBMIT_EVENT} target="_blank" rel="noopener noreferrer">Submit an event</a>
         <a href="/get-involved">Add your group</a>
         <a href={`${root}#subscribe`}>Newsletter</a>
       </div>

--- a/src/components/landing/LandingFooter.astro
+++ b/src/components/landing/LandingFooter.astro
@@ -47,7 +47,7 @@ const year = new Date().getFullYear();
       <div class="footer-col">
         <h4>Follow</h4>
         <a href={LINKEDIN} target="_blank" rel="noopener noreferrer">LinkedIn</a>
-        <a href={X} target="_blank" rel="noopener noreferrer">X</a>
+        <a href={X} target="_blank" rel="noopener noreferrer" aria-label="X (formerly Twitter)">X</a>
         <a href={INSTAGRAM} target="_blank" rel="noopener noreferrer">Instagram</a>
         <a href={THREADS} target="_blank" rel="noopener noreferrer">Threads</a>
       </div>

--- a/src/components/landing/LandingFooter.astro
+++ b/src/components/landing/LandingFooter.astro
@@ -1,6 +1,9 @@
 ---
 import { COMMUNITY } from "../../data/community";
-const { slack: SLACK, discord: DISCORD, github: GITHUB } = COMMUNITY;
+const {
+  slack: SLACK, discord: DISCORD, github: GITHUB,
+  linkedin: LINKEDIN, x: X, instagram: INSTAGRAM, threads: THREADS,
+} = COMMUNITY;
 
 // `subpage`: the anchor targets live on the landing page, so links get a
 // "/" prefix when the footer renders anywhere else.
@@ -39,6 +42,13 @@ const year = new Date().getFullYear();
         <a href={SLACK} target="_blank" rel="noopener noreferrer">Slack</a>
         <a href={DISCORD} target="_blank" rel="noopener noreferrer">Discord</a>
         <a href={GITHUB} target="_blank" rel="noopener noreferrer">GitHub</a>
+      </div>
+      <div class="footer-col">
+        <h4>Follow</h4>
+        <a href={LINKEDIN} target="_blank" rel="noopener noreferrer">LinkedIn</a>
+        <a href={X} target="_blank" rel="noopener noreferrer">X</a>
+        <a href={INSTAGRAM} target="_blank" rel="noopener noreferrer">Instagram</a>
+        <a href={THREADS} target="_blank" rel="noopener noreferrer">Threads</a>
       </div>
     </div>
   </div>

--- a/src/components/landing/LandingFooter.astro
+++ b/src/components/landing/LandingFooter.astro
@@ -3,7 +3,7 @@ import { COMMUNITY } from "../../data/community";
 const {
   slack: SLACK, discord: DISCORD, github: GITHUB,
   linkedin: LINKEDIN, x: X, instagram: INSTAGRAM, threads: THREADS,
-  submitEvent: SUBMIT_EVENT,
+  submitEvent: SUBMIT_EVENT, addGroup: ADD_GROUP,
 } = COMMUNITY;
 
 // `subpage`: the anchor targets live on the landing page, so links get a
@@ -35,7 +35,7 @@ const year = new Date().getFullYear();
       <div class="footer-col">
         <h4>Get involved</h4>
         <a href={SUBMIT_EVENT} target="_blank" rel="noopener noreferrer">Submit an event</a>
-        <a href="/get-involved">Add your group</a>
+        <a href={ADD_GROUP} target="_blank" rel="noopener noreferrer">Add your group</a>
         <a href={`${root}#subscribe`}>Newsletter</a>
       </div>
       <div class="footer-col">

--- a/src/components/landing/SubmitCTA.astro
+++ b/src/components/landing/SubmitCTA.astro
@@ -1,7 +1,7 @@
 ---
 import { COMMUNITY } from "../../data/community";
-const GITHUB = COMMUNITY.github;
 const SUBMIT_EVENT = COMMUNITY.submitEvent;
+const ADD_GROUP = COMMUNITY.addGroup;
 ---
 <section class="section submit-section" id="submit">
   <div class="submit-card">
@@ -10,7 +10,7 @@ const SUBMIT_EVENT = COMMUNITY.submitEvent;
       <p>Get it in front of every technologist in Hampton Roads. List your meetup, add a one-off event, or feature a conference — it's free.</p>
       <div class="submit-actions">
         <a class="btn-coral" href={SUBMIT_EVENT} target="_blank" rel="noopener noreferrer">Submit an event</a>
-        <a class="btn-ghost-dark" href={GITHUB} target="_blank" rel="noopener noreferrer">Add your group</a>
+        <a class="btn-ghost-dark" href={ADD_GROUP} target="_blank" rel="noopener noreferrer">Add your group</a>
       </div>
     </div>
     <div class="submit-art" aria-hidden="true">

--- a/src/components/landing/SubmitCTA.astro
+++ b/src/components/landing/SubmitCTA.astro
@@ -1,6 +1,7 @@
 ---
 import { COMMUNITY } from "../../data/community";
 const GITHUB = COMMUNITY.github;
+const SUBMIT_EVENT = COMMUNITY.submitEvent;
 ---
 <section class="section submit-section" id="submit">
   <div class="submit-card">
@@ -8,7 +9,7 @@ const GITHUB = COMMUNITY.github;
       <h2>Running a group or event?</h2>
       <p>Get it in front of every technologist in Hampton Roads. List your meetup, add a one-off event, or feature a conference — it's free.</p>
       <div class="submit-actions">
-        <a class="btn-coral" href="/get-involved">Submit an event</a>
+        <a class="btn-coral" href={SUBMIT_EVENT} target="_blank" rel="noopener noreferrer">Submit an event</a>
         <a class="btn-ghost-dark" href={GITHUB} target="_blank" rel="noopener noreferrer">Add your group</a>
       </div>
     </div>

--- a/src/data/community.ts
+++ b/src/data/community.ts
@@ -6,6 +6,7 @@ export const COMMUNITY = {
   discord: "https://discord.gg/bPGsCKBqWp",
   github: "https://github.com/RevolutionVA/757-community-site-public",
   submitEvent: "https://github.com/RevolutionVA/757-community-site-public/issues/new?template=submit-upcoming-event.yml",
+  addGroup: "https://github.com/RevolutionVA/757-community-site-public/issues/new?template=add-your-group.yml",
   linkedin: "https://www.linkedin.com/company/757tech",
   x: "https://x.com/757techorg",
   instagram: "https://www.instagram.com/757techorg/",

--- a/src/data/community.ts
+++ b/src/data/community.ts
@@ -1,5 +1,6 @@
 // Shared community / external links. Slack invite links rotate periodically —
-// update them here so every component stays in sync.
+// update them here so every component stays in sync. The README's "Follow
+// 757tech" section hardcodes these same URLs — update it in the same pass.
 export const COMMUNITY = {
   slack: "https://join.slack.com/t/757dev/shared_invite/zt-37d031yip-yI9z3ez8ezf~mJTy5ICaeQ",
   discord: "https://discord.gg/bPGsCKBqWp",

--- a/src/data/community.ts
+++ b/src/data/community.ts
@@ -4,6 +4,7 @@ export const COMMUNITY = {
   slack: "https://join.slack.com/t/757dev/shared_invite/zt-37d031yip-yI9z3ez8ezf~mJTy5ICaeQ",
   discord: "https://discord.gg/bPGsCKBqWp",
   github: "https://github.com/RevolutionVA/757-community-site-public",
+  submitEvent: "https://github.com/RevolutionVA/757-community-site-public/issues/new?template=submit-upcoming-event.yml",
   linkedin: "https://www.linkedin.com/company/757tech",
   x: "https://x.com/757techorg",
   instagram: "https://www.instagram.com/757techorg/",

--- a/src/data/community.ts
+++ b/src/data/community.ts
@@ -4,4 +4,8 @@ export const COMMUNITY = {
   slack: "https://join.slack.com/t/757dev/shared_invite/zt-37d031yip-yI9z3ez8ezf~mJTy5ICaeQ",
   discord: "https://discord.gg/bPGsCKBqWp",
   github: "https://github.com/RevolutionVA/757-community-site-public",
+  linkedin: "https://www.linkedin.com/company/757tech",
+  x: "https://x.com/757techorg",
+  instagram: "https://www.instagram.com/757techorg/",
+  threads: "https://www.threads.com/@757techorg",
 };

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -418,10 +418,10 @@ section[id], #subscribe { scroll-margin-top: 86px; }
 .footer-inner { max-width: 1200px; margin: 0 auto; padding: 56px 28px 36px; display: grid; grid-template-columns: 1.4fr 1.6fr; gap: 48px; }
 .footer-brand img { height: 64px; margin-bottom: 16px; }
 .footer-brand p { color: var(--muted); font-size: 14.5px; max-width: 360px; line-height: 1.55; margin: 0; }
-.footer-cols { display: grid; grid-template-columns: repeat(3, 1fr); gap: 28px; }
+.footer-cols { display: grid; grid-template-columns: repeat(4, 1fr); gap: 28px; }
 .footer-col h4 { font-family: var(--font-head); font-weight: 700; font-size: 14px; color: var(--deep); text-transform: uppercase; letter-spacing: .06em; margin-bottom: 14px; }
 .footer-col a { display: block; color: var(--muted); font-size: 14.5px; padding: 5px 0; transition: color .15s; }
 .footer-col a:hover { color: var(--tide); }
 .footer-base { max-width: 1200px; margin: 0 auto; padding: 20px 28px; border-top: 1px solid var(--line); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 10px; font-size: 13.5px; color: var(--muted); }
 .footer-tag { font-family: var(--font-head); font-weight: 600; color: var(--deep); }
-@media (max-width: 720px) { .footer-inner { grid-template-columns: 1fr; gap: 32px; } }
+@media (max-width: 720px) { .footer-inner { grid-template-columns: 1fr; gap: 32px; } .footer-cols { grid-template-columns: repeat(2, 1fr); row-gap: 24px; } }

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -424,4 +424,5 @@ section[id], #subscribe { scroll-margin-top: 86px; }
 .footer-col a:hover { color: var(--tide); }
 .footer-base { max-width: 1200px; margin: 0 auto; padding: 20px 28px; border-top: 1px solid var(--line); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 10px; font-size: 13.5px; color: var(--muted); }
 .footer-tag { font-family: var(--font-head); font-weight: 600; color: var(--deep); }
-@media (max-width: 720px) { .footer-inner { grid-template-columns: 1fr; gap: 32px; } .footer-cols { grid-template-columns: repeat(2, 1fr); row-gap: 24px; } }
+@media (max-width: 960px) { .footer-cols { grid-template-columns: repeat(2, 1fr); row-gap: 24px; } }
+@media (max-width: 720px) { .footer-inner { grid-template-columns: 1fr; gap: 32px; } }


### PR DESCRIPTION
## Summary
- **Social links:** new **Follow** column in the landing footer (LinkedIn, X, Instagram, Threads — all `@757techorg`), centralized in `src/data/community.ts`; README gets a "Follow 757tech" section. Footer grid 3 → 4 columns, wrapping 2×2 below 960px.
- **Submit an event:** CTA button and footer link now open the `submit-upcoming-event.yml` issue template directly (was `/get-involved` and a `#submit` anchor).
- **Add your group:** new `add-your-group.yml` issue template (group name, URL, Meetup RSS feed, category, tags, description, cadence, CoC) mirroring the event template; CTA button and footer link point at it (was repo root and `/get-involved`).
- Review feedback applied: 960px footer breakpoint for tablet widths, `aria-label` on the X link, drift-reminder comment for the README-duplicated URLs.

Build verified (`astro build`, 9 pages); both template links render in `dist/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZoFzndAXXLUhhTrvDV7iY