### PR TITLE
Add Google Analytics (GA4) tag to site layouts

### DIFF
--- a/src/components/GoogleAnalytics.astro
+++ b/src/components/GoogleAnalytics.astro
@@ -2,33 +2,52 @@
 // Google Analytics (GA4). Shared by MainLayout and LandingLayout so the ID
 // lives in one place.
 //
-// Only emitted in production builds — `astro dev`, `astro preview`, and PR
-// staging deploys would otherwise report into the real property.
+// Two layers keep non-production traffic out of the real property:
 //
-// Both tags are `is:inline` so Astro emits them verbatim. Bundled as an ES
-// module, `gtag`/`dataLayer` would be scoped to the module instead of `window`
-// and the snippet would break.
+//   1. `import.meta.env.PROD` — omits the tag entirely under `astro dev`.
+//      This is a build-time flag, so it is true for ANY `astro build`,
+//      including `npm run preview` and the Azure PR staging deploys.
+//   2. The hostname guard below — a runtime check, which is the only thing
+//      that can distinguish a staging deploy from production, since both are
+//      the same static build.
 //
-// The body is injected via `set:html` rather than `define:vars` because
-// define:vars wraps the script in an IIFE, which would leave `gtag` non-global
-// and break any later `gtag('event', ...)` call. Expressions aren't evaluated
-// inside a <script> body, so set:html is how the ID gets interpolated.
+// The guard is a blocklist of ephemeral hosts rather than an allowlist on
+// 757tech.org, so analytics fail open: if the production domain ever changes,
+// tracking keeps working instead of silently going dark.
+//
+// gtag.js is injected from inside the guard rather than sitting in a static
+// <script src>, so excluded hosts make no request to Google at all.
+//
+// `is:inline` keeps Astro from bundling this as an ES module, which would
+// scope `dataLayer`/`gtag` to the module. `gtag` is assigned onto `window`
+// explicitly because the IIFE (needed for the early return) would otherwise
+// leave it non-global and break later `gtag('event', ...)` calls.
 const GA_MEASUREMENT_ID = "G-X4L41HRW7E";
 
-const gtagSnippet = `
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
+// `.azurestaticapps.net` covers the Azure PR staging deploys; localhost covers
+// `npm run preview`, which serves a production build and so gets past #1.
+const EXCLUDED_HOST_SUFFIXES = [".azurestaticapps.net", "localhost", "127.0.0.1"];
 
-  gtag('config', '${GA_MEASUREMENT_ID}');
+const gtagSnippet = `
+  (function () {
+    var excluded = ${JSON.stringify(EXCLUDED_HOST_SUFFIXES)};
+    var host = window.location.hostname;
+    for (var i = 0; i < excluded.length; i++) {
+      if (host === excluded[i] || host.endsWith(excluded[i])) return;
+    }
+
+    var s = document.createElement('script');
+    s.async = true;
+    s.src = 'https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}';
+    document.head.appendChild(s);
+
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = function gtag(){dataLayer.push(arguments);};
+    gtag('js', new Date());
+
+    gtag('config', '${GA_MEASUREMENT_ID}');
+  })();
 `;
 ---
 
-{
-  import.meta.env.PROD && (
-    <>
-      <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`} />
-      <script is:inline set:html={gtagSnippet} />
-    </>
-  )
-}
+{import.meta.env.PROD && <script is:inline set:html={gtagSnippet} />}

--- a/src/components/GoogleAnalytics.astro
+++ b/src/components/GoogleAnalytics.astro
@@ -1,0 +1,34 @@
+---
+// Google Analytics (GA4). Shared by MainLayout and LandingLayout so the ID
+// lives in one place.
+//
+// Only emitted in production builds — `astro dev`, `astro preview`, and PR
+// staging deploys would otherwise report into the real property.
+//
+// Both tags are `is:inline` so Astro emits them verbatim. Bundled as an ES
+// module, `gtag`/`dataLayer` would be scoped to the module instead of `window`
+// and the snippet would break.
+//
+// The body is injected via `set:html` rather than `define:vars` because
+// define:vars wraps the script in an IIFE, which would leave `gtag` non-global
+// and break any later `gtag('event', ...)` call. Expressions aren't evaluated
+// inside a <script> body, so set:html is how the ID gets interpolated.
+const GA_MEASUREMENT_ID = "G-X4L41HRW7E";
+
+const gtagSnippet = `
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '${GA_MEASUREMENT_ID}');
+`;
+---
+
+{
+  import.meta.env.PROD && (
+    <>
+      <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`} />
+      <script is:inline set:html={gtagSnippet} />
+    </>
+  )
+}

--- a/src/layouts/LandingLayout.astro
+++ b/src/layouts/LandingLayout.astro
@@ -60,6 +60,16 @@ import "../styles/landing.css";
       rel="stylesheet"
     />
 
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-X4L41HRW7E"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-X4L41HRW7E');
+    </script>
+
     <!-- Bento Tracking -->
     <script src="https://fast.bentonow.com?site_uuid=57d9b8196b2b704a30da5ac245bf2cfe&js=true" async defer></script>
     <script>

--- a/src/layouts/LandingLayout.astro
+++ b/src/layouts/LandingLayout.astro
@@ -24,6 +24,8 @@ const fullTitle = `${title} | 757 Tech Community`;
 // Global (non-scoped) landing styles — see the file header for why they can't
 // be Astro-scoped. Component-specific tweaks live in each component's <style>.
 import "../styles/landing.css";
+
+import GoogleAnalytics from "../components/GoogleAnalytics.astro";
 ---
 
 <!DOCTYPE html>
@@ -61,14 +63,7 @@ import "../styles/landing.css";
     />
 
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-X4L41HRW7E"></script>
-    <script is:inline>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-X4L41HRW7E');
-    </script>
+    <GoogleAnalytics />
 
     <!-- Bento Tracking -->
     <script src="https://fast.bentonow.com?site_uuid=57d9b8196b2b704a30da5ac245bf2cfe&js=true" async defer></script>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -1,4 +1,6 @@
 ---
+import GoogleAnalytics from "../components/GoogleAnalytics.astro";
+
 interface Props {
   title: string;
   description?: string;
@@ -48,14 +50,7 @@ const fullTitle = `${title} | 757 Tech Community`;
     <link rel="stylesheet" href="/styles/global.css" />
 
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-X4L41HRW7E"></script>
-    <script is:inline>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-X4L41HRW7E');
-    </script>
+    <GoogleAnalytics />
 
     <!-- Bento Tracking -->
     <script src="https://fast.bentonow.com?site_uuid=57d9b8196b2b704a30da5ac245bf2cfe&js=true" async defer></script>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -46,7 +46,17 @@ const fullTitle = `${title} | 757 Tech Community`;
     <meta property="twitter:image" content={`${siteUrl}${image}`} />
     
     <link rel="stylesheet" href="/styles/global.css" />
-    
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-X4L41HRW7E"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-X4L41HRW7E');
+    </script>
+
     <!-- Bento Tracking -->
     <script src="https://fast.bentonow.com?site_uuid=57d9b8196b2b704a30da5ac245bf2cfe&js=true" async defer></script>
     <script>


### PR DESCRIPTION
## Summary

Adds the Google Analytics 4 gtag.js snippet (`G-X4L41HRW7E`) to the site.

The tag went into the two layouts that actually render pages:

- `src/layouts/MainLayout.astro` — the 7 content pages (meetups, calendar, conferences, learning, work, get-involved, communities)
- `src/layouts/LandingLayout.astro` — home + newsletter-thank-you

Two implementation notes:

- The config block uses `<script is:inline>`. Without it, Astro bundles inline scripts as ES modules, which would scope `gtag`/`dataLayer` to the module and break the snippet. The remote `gtag/js` script is left untouched by Astro either way.
- `src/layouts/Layout.astro` is unused Astro boilerplate (no page imports it), so it was skipped.

## Test plan

- [x] `npm run build` succeeds — 9 pages built
- [x] `G-X4L41HRW7E` present in all 9 generated HTML files in `dist/`
- [ ] After deploy, confirm pageviews land in the GA4 property (Realtime report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
