### PR TITLE
chore: add Impeccable design artifacts and Solo config

### DIFF
--- a/.github/hooks/impeccable.json
+++ b/.github/hooks/impeccable.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "hooks": {
+    "postToolUse": [
+      {
+        "type": "command",
+        "matcher": "edit|create|apply_patch",
+        "bash": "[ ! -f \"$(git rev-parse --show-toplevel)/.github/skills/impeccable/scripts/hook.mjs\" ] || ! node -e \"process.exit(Math.min(parseInt(process.versions.node,10),22)===22?0:1)\" 2>/dev/null || node \"$(git rev-parse --show-toplevel)/.github/skills/impeccable/scripts/hook.mjs\"",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,11 @@ social/exports/
 
 # scraped member photo archive (large, not tracked)
 social/event-photos/
+
+# impeccable: per-developer state, not shared
+.impeccable/config.local.json
+.impeccable/hook.cache.json
+.impeccable/live/sessions/
+
+# cursor hook manifest holds a machine-absolute skill path
+.cursor/hooks.json

--- a/.impeccable/config.json
+++ b/.impeccable/config.json
@@ -1,0 +1,9 @@
+{
+  "detector": {
+    "ignoreRules": [],
+    "ignoreFiles": [
+      "scripts/create-bento-broadcast.js"
+    ],
+    "ignoreValues": []
+  }
+}

--- a/.impeccable/critique/2026-08-10T22-20-36Z__src-pages-index-astro.md
+++ b/.impeccable/critique/2026-08-10T22-20-36Z__src-pages-index-astro.md
@@ -1,0 +1,126 @@
+---
+target: src/pages/index.astro
+total_score: 19
+max_score: 40
+na_heuristics: 
+p0_count: 2
+p1_count: 2
+timestamp: 2026-08-10T22-20-36Z
+slug: src-pages-index-astro
+---
+Method: dual-agent (A: design review · B: detector + browser evidence, isolated, parallel)
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 1 | `.chip-count` is server-rendered once and never recomputed — reads "All 35" while the week view shows 5 and a zero-result search still shows 35. No freshness stamp, despite "updated every 6 hours" being core positioning. |
+| 2 | Match System / Real World | 3 | Coastal language is committed and consistent; times are real ET. Undercut by generic "List / Week / Month" and by "Community" — a code-level fallback — surfacing as a real chip. |
+| 3 | User Control and Freedom | 2 | Reset, search-clear, and This week/This month pills are all present. But List→Week collapses ~2,600px with no scroll anchoring and dumps you at the footer; no URL state, so nothing is shareable. |
+| 4 | Consistency and Standards | 2 | Two chip systems that disagree (events chips carry counts and include "Community"; group chips don't and include Cloud/Design). `.wc-today` sets white on coral — 2.74:1 — which DESIGN.md's own Navy-On-Coral Rule forbids by name. |
+| 5 | Error Prevention | 2 | `required` + `pattern` on email and a stray-Enter guard. But the hero demands first *and* last name for a free newsletter with no stated reason, and there is no inline error copy. |
+| 6 | Recognition Rather Than Recall | 2 | Date badges and category dots are well-built, but hues 168/192/200/150 are not discriminable and there's no legend. Group marks collide: "HA" ×5, "75" ×3, "VI" ×2 — while real cached group images sit unused. |
+| 7 | Flexibility and Efficiency | 2 | Three views, filter, and search give a returning attendee a path — but no deep links, no persisted state, no keyboard affordance, and no "add to calendar"/ICS on a product that *is* a calendar. |
+| 8 | Aesthetic and Minimalist Design | 3 | Palette, type, radii, and the flat-at-rest/lift-on-hover model are disciplined. Dragged down by 35 undifferentiated cards, a one-card conferences band stranded at far left, and ~208px dead zones between sections. |
+| 9 | Error Recovery | 1 | One generic empty state for every failure mode, with no explanation of the actual constraint (search covers only the next 8 weeks of *events*, not groups or conferences). No form error copy at all. |
+| 10 | Help and Documentation | 1 | Nothing says what the Monday digest contains, when it arrives, or what a past issue looks like. "Automated aggregation plus human verification" — PRODUCT.md's #1 uncopyable claim — appears nowhere on the page. |
+| **Total** | | **19/40** | **Poor band — but see Overall Impression: the deficit is informational, not visual.** |
+
+## Design Specificity Verdict
+
+**LLM assessment.** Roughly 60% authored, 40% off-the-shelf — and the off-the-shelf part is the part that does the actual job. Genuinely product-specific: the coastal token system, the Baloo 2 / DM Sans pairing that makes a directory read as an invitation, the `WaveDivider` silhouette, the voice ("in one tide", "Worth the drive", "20 groups, one tide"), the ET-locked date math that refuses to drift with the viewer's clock, the one-hue-per-category OKLCH derivation, and the hero's next-event peek — the most product-specific composition on the page, because it commits to showing *every* event on the nearest date rather than one hero event.
+
+Category-interchangeable: the entire `EventsExplorer` interaction model. Filter chips + search + List/Week/Month over an auto-fill card grid is the stock events-directory pattern; recolor it and it's Luma or any city tech calendar. `Groups.astro` is a generic initial-avatar directory row. `SubmitCTA` is a stock SaaS band — navy gradient, dot-grid overlay, blurred radial blob, floating white chip — and could sit on a fintech pricing page unchanged.
+
+The deeper failure is a mismatch between the stated North Star and the shipped default. DESIGN.md says "The Tide Chart" — an object whose entire subject is *when*. The default state is a 35-card grid sorted by date but chunked by nothing, with a category filter as the primary control: an object whose subject is *what*. The one surface that genuinely is a tide chart — the week view, with seven columns, a coral ring on today, and a live "5 events" subhead — is hidden behind the second tab. **The brand is authored for this product; the information architecture is borrowed.**
+
+**Deterministic scan.** CLI detector: 1 advisory finding across `src/pages/index.astro` + `src/components/landing` (exit 2); the page file alone scanned clean (exit 0). Browser overlay: 21 findings across 13 element groups — `cramped-padding` ×7, `kicker-above-heading` ×4, `low-contrast` ×2, `layout-transition` ×2, `dark-glow` ×2, plus one each of `gpt-thin-border-wide-shadow`, `ai-color-palette`, `skipped-heading`, `repeating-stripes-gradient`. Deduped to unique causes it's ~11 distinct issues, not 21: seven of them are one `.ec-date` rule repeated across seven cards, and four more are the same section-kicker pattern across four components.
+
+Where the two agreed: **coral contrast**. The detector independently flagged `.peek-label` at 2.7:1 on white, which the design review found as a systemic pattern across `.kicker`, `.ec-rel` (2.44:1), and `.ec-dow` (2.55:1). Two methods, same conclusion, different entry points — that's the strongest signal in this report.
+
+What the detector caught that the review missed: `cramped-padding` on `.ec-date` (`padding: 9px 0 7px` — zero horizontal inset on a 64px tile, ×7 instances), a `skipped-heading` (h2 "Running a group or event?" → h4 "Explore", no h3), `gpt-thin-border-wide-shadow` on `.hero-peek` (1px border + 40px blur), and `transition: padding` on the sticky header — a layout-animating property that can jank on scroll.
+
+False positives, verified and dismissed: the `#fff` color finding (DESIGN.md defines `#ffffff`; the detector doesn't normalize 3-digit shorthand), both `dark-glow` hits (they're the documented `--shadow-lg` and coral-glow tokens), `ai-color-palette` on `.art-wave` (seafoam→tide are the brand palette, not generic AI cyan), and `repeating-stripes-gradient` (an intentional 14%-tint fallback behind missing conference photos).
+
+**Visual overlays.** Injection succeeded — mutation was proven by preflight, the helper ran on port 8400, `detect.js` was injected and its console output captured, and the server was stopped cleanly afterward. The overlay tab has since been closed, so there is no live overlay in your browser now; the findings above are the captured result.
+
+## Overall Impression
+
+This is a genuinely well-made page carrying a borrowed skeleton. The craft is real and unusual — a coherent token system, contrast reasoning committed to code comments, timezone-correct date math, generated category color with sRGB fallbacks. Almost nothing here is sloppy.
+
+But the 19/40 is not a scoring accident, and it's worth reading precisely: heuristic 8 (aesthetics) scored 3 while status, error recovery, and help all scored 1. **The deficit is informational, not visual.** The page is beautiful and it does not tell you what's happening. Counts lie after you filter, empty states don't explain the constraint that produced them, and nothing on the page says what the thing you're being asked to subscribe to actually is.
+
+The single biggest opportunity: **make the week the default.** The tide chart already exists, fully built, correctly responsive, with today marked in the system's own urgency color — and it's behind a tab nobody is told about. Flipping one variable moves the page from answering "what kinds of tech exist here" to answering "what can I go to this week," which is the exact job PRODUCT.md says the primary user came to do.
+
+## What's Working
+
+1. **The token system produces a surface that could not have come out of a template.** One palette, warm `--line` borders instead of neutral grey, navy-tinted shadows instead of black, and the flat-at-rest/lift-on-hover rule applied consistently across event, featured, conference, and group cards — each with its own considered displacement (−3px, −4px, −5px, and `translateX(3px)` for the group *list*, because a list moves sideways). The Navy-On-Coral decision, with 4.96:1 vs 2.74:1 reasoning committed to a code comment, is evidence of a system that argues with itself rather than picking a look.
+
+2. **The week view is the right object, correctly built.** It groups by day rather than category, marks today with the system's urgency color, shows a live count in its subhead, keeps past events visible at 48% opacity instead of hiding them, and restructures to a left-rail day list at ≤860px rather than crushing seven columns. It is the tide chart the brief asks for. It is also the second tab.
+
+3. **The data plumbing is honest, and the honesty shows in the UI.** Chip counts are tallied in one pass from events actually present, so per-chip counts always sum to All even if a new category appears. Times render through `Intl` locked to `America/New_York`. Category colors derive from one hue at fixed lightness/chroma. Every OKLCH ships a computed sRGB hex beside it. Nothing on this page is invented — exactly what PRODUCT.md's no-fabrication rule demands.
+
+## Priority Issues
+
+### [P0] The default view is a list, not the week
+**What:** `EventsExplorer.astro` ships `<button class="active" data-view="list">` (line 66) and initializes `let view = "list"` (line 146). *Verified in source.* The entry point into the calendar is a 35-card, 8-week, category-filterable grid.
+**Why it matters:** PRODUCT.md states the primary user's job is "find one thing worth going to this week"; DESIGN.md's North Star is an object whose whole subject is *when*. The default answers "what kinds of tech exist here" instead. The view that answers the real question in one screen is a tab most visitors never click, and nothing on the page tells them it exists.
+**Fix:** Default `view = "week"` and mark the Week button active in markup. Relabel the toggle to `This week / Month / All events` so the options describe scope, not layout. Server-render the current week into `.calendar-wrap` in `index.astro` — `weekDays()` already runs in Node — so the answer is in the HTML before hydration.
+**Suggested command:** `/impeccable layout`
+
+### [P0] The page ends with an organizer ask, and the digest is sold without proof
+**What:** `index.astro` renders `<SubmitCTA />` as the final section before the footer. The `.news-section` closing-subscribe styles exist in `landing.css` (288–300) and **no component uses them** — *verified: zero references in `src/`*. The hero form's only support is 13.5px of `.hero-mini` text.
+**Why it matters:** Success is measured in subscribers, and PRODUCT principle 2 says every surface earns the subscription. The last impression instead targets ~20 organizers region-wide. Meanwhile the strongest available reassurance — real, human-verified past digests in `weekly-meetups/`, already browsable at `/weekly/` — is mentioned once, in the footer, as "Weekly archive." Peak-end is being actively worked against: the strongest moment is behind a tab, and the final moment belongs to a secondary audience.
+**Fix:** Add a closing subscribe band below `<SubmitCTA />` using the existing dead `.news-section` styles and the same Bento action from `SplitHero.astro`. Add a "See what last Monday's digest looked like →" link to `/weekly/` beside `.hero-mini`, plus one line naming what's inside.
+**Suggested command:** `/impeccable clarify`
+
+### [P1] Coral fails AA everywhere it carries meaning — and one rule violates the design system by name
+**What:** `#FF6F59` on white is **2.75:1** (`.kicker` on all four section headers, `.peek-label`). On `color-mix(coral 12%, #fff)` it is **2.44:1** — that's `.ec-rel`, the Today/Tomorrow pill, the single most important urgency signal on the page. On `--sand-soft` it is **2.55:1** (`.ec-dow`, on every date badge). And `.wc-today` (landing.css:187) sets `color: #fff` on `background: var(--coral)` = **2.74:1** — *verified in source* — which DESIGN.md's Navy-On-Coral Rule forbids explicitly. The dead `.capture button` block (landing.css:54–59) repeats the same violation.
+**Both assessments found this independently.**
+**Why it matters:** Coral is the designated color of *now*. Every time-critical cue on the page is rendered in a color low-vision users, bright-daylight phone users, and anyone on a dim screen cannot read. The system solved this once for buttons and never generalized it.
+**Fix:** Add a `--coral-ink` token to `tokens.css` — darkened coral at the same hue, ≥4.5:1 on both `#fff` and `--sand-soft` — and use it for every coral *text* rule (`.kicker`, `.peek-label`, `.ec-rel`, `.ec-dow`, `.fd-*`). Keep `--coral` for fills only. Change `.wc-today` to `color: var(--deep)`. Delete the dead `.capture` block. **Also correct DESIGN.md**, which currently prescribes coral kickers on white — that instruction is wrong and will propagate.
+**Suggested command:** `/impeccable colorize`
+
+### [P1] Switching views throws the user to the footer, and filter state is neither shown nor announced
+**What:** The `viewBtns` handler (`EventsExplorer.astro`:317–332) swaps `display` with no scroll compensation; List→Week removes ~2,600px above the scroll position, landing the user in the footer. Separately `.chip-count` is baked server-side from the 8-week window and never recomputed, and neither `.chip` nor the view buttons carry ARIA state (live DOM shows only `class` and `data-cat`).
+**Why it matters:** The one interaction that most improves the experience actively punishes the person who tries it. And because counts never move, the interface confidently reports "35" over an empty grid — the worst possible status signal.
+**Fix:** Capture `section.getBoundingClientRect().top` before the DOM swap and restore scroll after. Recompute chip counts inside `render()` scoped to the active view's date range. Add `aria-pressed` to `.chip`, `role="tablist"` + `aria-selected` on the view toggle, and an `aria-live="polite"` "Showing N of M events" line above `.event-grid`.
+**Suggested command:** `/impeccable harden`
+
+### [P2] Groups answers neither of the newcomer's unknowns; Conferences renders as broken at n=1; date badges are cramped
+**What:** `Groups.astro` renders 20 alphabetical rows keyed by two-letter initials — "HA" ×5, "75" ×3, "VI" ×2 — with tags but no dates, while `public/images/meetups/` already holds cached per-group images and `MeetupImage.astro` already exists to render them. `.conf-grid` uses `auto-fill, minmax(270px, 1fr)`, so today's single upcoming conference sits alone at the far left of a full-bleed sand band with ~900px of empty sand beside it. And the detector's `cramped-padding` ×7: `.ec-date` is `padding: 9px 0 7px` — zero horizontal inset on a 64px tile.
+**Why it matters:** PRODUCT.md says the newcomer doesn't know which groups exist "**or which are alive**." A directory with no recency signal cannot make that distinction — the exact judgment the primary user came to make. And a one-card band reads as abandoned, not curated, undercutting "completeness is the credibility."
+**Fix:** Replace `.group-mark` initials with the cached group image (initials as fallback) via `MeetupImage.astro`. Add a "Next: Tue Aug 18" line per card from the `meetupByName` map already built in `index.astro`, sorted by soonest, with dormant groups last. Give `.conf-grid` a `max-width` + `margin-inline: auto` so small-n states read as centered. Add horizontal padding to `.ec-date`.
+**Suggested command:** `/impeccable polish`
+
+## Persona Red Flags
+
+**Jordan (Confused First-Timer), on a phone.** First screen: headline, paragraph, three input fields — first name, last name, email — before any event exists. Scrolls past the logo (second time, after the header) to three cards all dated Wed Aug 12 with no framing that says "this week." Hits **Featured events**: Sep 17 and Oct 9, five and eight weeks out, under a header saying "Don't miss" — noise for someone deciding tonight. Reaches the explorer: four chips whose distinction ("Development" vs "Technology") is meaningless to a newcomer. Then 35 cards in which "Peninsula Builders Study Group" appears on Aug 18, Sep 1, Sep 15, and Sep 29, and "Norfolk Cybersecurity Networking & Happy Hour" three times. Conclusion: *nothing much happens here, and it's all the same thing.* Specific breakages: `.ec-rel` — Jordan's only temporal anchor — renders on zero cards today, because the nearest event is +2 days; there are no date-group headings; the week view isn't the default; and at ≤860px `.week-col.empty { display: none }` removes today's column entirely when today is empty, so even in the week view on mobile, the coral "Today" marker vanishes at exactly the moment Jordan needs to know where "now" is.
+
+**Casey (Distracted Mobile User).** 15,303px tall at 390px — about 19 thumb-screens. The header at rest shows a burger and a coral Subscribe with the brand at `opacity: 0`, so there's no left anchor. Casey taps **Month** to skim and gets colored slivers measuring **22.1 × 46px** — under WCAG 2.2's 24px minimum — with `.me-t { display: none }` at ≤640px, so the only visible label is a time overflowing its box: "6:3", "9:3 AM". Tapping is a coin flip. Back in List, tapping the Development chip leaves the count reading 12 with no statement of what's now on screen. Every event card is `target="_blank"`, so exploring three events leaves three orphan tabs and no path back. The explorer bar isn't sticky, so changing a filter after eight cards means scrolling all the way up.
+
+**Riley (Deliberate Stress Tester).** Searches `python`: zero results, palm tree, generic message — while "757 Python Users Group" sits ~4,000px below on the same page, unsearched, because the `search` field in `toVM()` only indexes events. Searches `cloud`: no Cloud chip exists in the events row, but a Cloud chip *does* exist in the Groups row below — two filter systems on one page disagreeing about what categories are. Clicks List→Week and is thrown to the footer. Tabs the chips: no `aria-pressed`, no `aria-selected` on the view toggle, so a screen reader is told nothing changed. Reloads after filtering: no URL state, everything resets. Enables `prefers-reduced-motion`: `.art-wave` correctly stops, but `html { scroll-behavior: smooth }` has no reduced-motion guard, so every anchor click still animates the viewport. Submits the hero form with just an email: blocked by `required` on both name fields, with no copy anywhere explaining why a free weekly email needs a last name — the highest-friction field on the page's highest-value action.
+
+## Minor Observations
+
+- **The wave divider is used exactly once**, in `SplitHero.astro` — *verified*. DESIGN.md calls it "the system's signature move: sections don't butt against each other, they wash into each other," but Events→Conferences and Conferences→Groups both butt hard. The signature is stated, used once, abandoned.
+- `.section` applies `clamp(64px, 9vw, 104px)` top *and* bottom, so adjacent sections carry up to **208px** of dead vertical space.
+- `.section-head` uses `justify-content: space-between`, stranding `.section-lead` ~400px from the h2 it describes — it reads as an unrelated caption.
+- `.hero-form` re-implements the pill-input styling `.capture` already defines, one of the two copies being dead. Consolidate into a `.field-pill` class in `chrome.css`.
+- The hero logo is a 2048×1117 PNG rendered at ~184px with no `srcset` — roughly 11× the needed pixels on the highest-priority above-fold image.
+- `.month-ev` relies on a `title` attribute for its tooltip, which is keyboard- and touch-inaccessible — and on mobile it's the *only* way to read the event name.
+- Event card link text concatenates the whole card into one accessible name ("WED 12 AUG 1 PM Technology (CS)²AI Online™ REPLAY…"). Add `aria-label` to the `<a>` and `aria-hidden` to `.ec-date`.
+- Nothing says when the calendar last refreshed, though the six-hour loop is one of two things PRODUCT.md says a competitor cannot copy. "Last updated 4 hours ago" is free credibility.
+- The `Community` category is a code-level fallback (`meetup?.category ?? "Community"`) that surfaces as a real clickable chip. Two of the three featured events are tagged Community — the marquee slot is dominated by events whose category failed to resolve.
+- Detector flagged `kicker-above-heading` ×4 as a saturated pattern. It's a legitimate call — the coral eyebrow above a heading is everywhere in current web design — but it is also the documented `label` role in DESIGN.md. Treat as advisory: the contrast problem is real, the pattern itself is a deliberate brand choice.
+- One `skipped-heading`: h2 "Running a group or event?" is followed by h4 "Explore" in the footer, with no h3 between.
+
+## Questions to Consider
+
+1. **If the week view were the entire Events section — no toggle, no chips, no search, just "This week" with prev/next arrows and a link to `/calendar` for everything else — what would actually be lost?** The primary user's job is one week wide. The 35-card list, the filter, and the month grid serve regular attendees and organizers, and PRODUCT.md is explicit that those audiences are served, not optimized for.
+
+2. **Four instances of "Peninsula Builders Study Group" in one scroll is a data-shape problem, not a card-design problem.** Should recurring series collapse into one entity — "757 Developers · Peninsula Builders Study Group — every other Tuesday, next Aug 18" — with occurrences expandable? That cuts 35 cards to ~15 distinct things and answers "which groups are alive" in the same stroke, because cadence *is* the aliveness signal.
+
+3. **The digest is the success metric, and the site already generates and archives the exact artifact the visitor would receive — so why is the page describing it instead of showing it?** A real, dated excerpt of last Monday's send, directly above the email field, is the only social proof this product can honestly offer, and it costs nothing because `weekly-meetups/` is already in the repo.
+
+4. **Coral is defined as "the color of *now*" — but on a page where the nearest event is 48 hours out, coral appears only on decorative kickers and the Subscribe button, and never on a single event.** Should "now" be computed and relative — the next event, tonight, this week — so the color always points at something, rather than an absolute that silently switches off whenever today is quiet?

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,235 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-08-10T21:34:57Z",
+  "title": "Design System: 757tech",
+  "extensions": {
+    "colorMeta": {
+      "deep": {
+        "role": "primary",
+        "displayName": "Harbor Navy",
+        "canonical": "oklch(0.2994 0.0631 240.67)",
+        "tonalRamp": ["oklch(0.15 0.0588 240.67)", "oklch(0.26 0.0619 240.67)", "oklch(0.38 0.0608 240.67)", "oklch(0.50 0.0574 240.67)", "oklch(0.62 0.0540 240.67)", "oklch(0.74 0.0506 240.67)", "oklch(0.85 0.0474 240.67)", "oklch(0.95 0.0446 240.67)"]
+      },
+      "deep-2": {
+        "role": "primary",
+        "displayName": "Deep Water",
+        "canonical": "oklch(0.3921 0.0875 241.93)",
+        "tonalRamp": ["oklch(0.15 0.0780 241.93)", "oklch(0.26 0.0823 241.93)", "oklch(0.38 0.0870 241.93)", "oklch(0.50 0.0832 241.93)", "oklch(0.62 0.0785 241.93)", "oklch(0.74 0.0738 241.93)", "oklch(0.85 0.0695 241.93)", "oklch(0.95 0.0655 241.93)"]
+      },
+      "tide": {
+        "role": "secondary",
+        "displayName": "Tide Cyan",
+        "canonical": "oklch(0.7159 0.1264 216.53)",
+        "tonalRamp": ["oklch(0.15 0.0942 216.53)", "oklch(0.26 0.1004 216.53)", "oklch(0.38 0.1073 216.53)", "oklch(0.50 0.1141 216.53)", "oklch(0.62 0.1209 216.53)", "oklch(0.74 0.1250 216.53)", "oklch(0.85 0.1187 216.53)", "oklch(0.95 0.1131 216.53)"]
+      },
+      "seafoam": {
+        "role": "secondary",
+        "displayName": "Seafoam",
+        "canonical": "oklch(0.7869 0.1067 181.50)",
+        "tonalRamp": ["oklch(0.15 0.0761 181.50)", "oklch(0.26 0.0814 181.50)", "oklch(0.38 0.0871 181.50)", "oklch(0.50 0.0929 181.50)", "oklch(0.62 0.0987 181.50)", "oklch(0.74 0.1044 181.50)", "oklch(0.85 0.1037 181.50)", "oklch(0.95 0.0989 181.50)"]
+      },
+      "coral": {
+        "role": "tertiary",
+        "displayName": "Signal Coral",
+        "canonical": "oklch(0.7138 0.1801 30.79)",
+        "tonalRamp": ["oklch(0.15 0.1344 30.79)", "oklch(0.26 0.1434 30.79)", "oklch(0.38 0.1531 30.79)", "oklch(0.50 0.1628 30.79)", "oklch(0.62 0.1725 30.79)", "oklch(0.74 0.1780 30.79)", "oklch(0.85 0.1691 30.79)", "oklch(0.95 0.1610 30.79)"]
+      },
+      "sand": {
+        "role": "neutral",
+        "displayName": "Warm Sand",
+        "canonical": "oklch(0.9282 0.0343 84.59)",
+        "tonalRamp": ["oklch(0.15 0.0223 84.59)", "oklch(0.26 0.0240 84.59)", "oklch(0.38 0.0259 84.59)", "oklch(0.50 0.0277 84.59)", "oklch(0.62 0.0296 84.59)", "oklch(0.74 0.0314 84.59)", "oklch(0.85 0.0331 84.59)", "oklch(0.95 0.0340 84.59)"]
+      },
+      "sand-soft": {
+        "role": "neutral",
+        "displayName": "Sea Foam Paper",
+        "canonical": "oklch(0.9743 0.0143 84.58)",
+        "tonalRamp": ["oklch(0.15 0.0090 84.58)", "oklch(0.26 0.0097 84.58)", "oklch(0.38 0.0104 84.58)", "oklch(0.50 0.0112 84.58)", "oklch(0.62 0.0120 84.58)", "oklch(0.74 0.0128 84.58)", "oklch(0.85 0.0135 84.58)", "oklch(0.95 0.0141 84.58)"]
+      },
+      "ink": {
+        "role": "neutral",
+        "displayName": "Squid Ink",
+        "canonical": "oklch(0.2540 0.0446 241.32)",
+        "tonalRamp": ["oklch(0.15 0.0425 241.32)", "oklch(0.26 0.0444 241.32)", "oklch(0.38 0.0420 241.32)", "oklch(0.50 0.0396 241.32)", "oklch(0.62 0.0372 241.32)", "oklch(0.74 0.0348 241.32)", "oklch(0.85 0.0326 241.32)", "oklch(0.95 0.0306 241.32)"]
+      },
+      "muted": {
+        "role": "neutral",
+        "displayName": "Driftwood Grey",
+        "canonical": "oklch(0.5388 0.0349 235.02)",
+        "tonalRamp": ["oklch(0.15 0.0288 235.02)", "oklch(0.26 0.0305 235.02)", "oklch(0.38 0.0324 235.02)", "oklch(0.50 0.0343 235.02)", "oklch(0.62 0.0336 235.02)", "oklch(0.74 0.0317 235.02)", "oklch(0.85 0.0300 235.02)", "oklch(0.95 0.0284 235.02)"]
+      },
+      "line": {
+        "role": "neutral",
+        "displayName": "Shell Line",
+        "canonical": "oklch(0.9039 0.0212 79.09)",
+        "tonalRamp": ["oklch(0.15 0.0140 79.09)", "oklch(0.26 0.0151 79.09)", "oklch(0.38 0.0162 79.09)", "oklch(0.50 0.0174 79.09)", "oklch(0.62 0.0185 79.09)", "oklch(0.74 0.0197 79.09)", "oklch(0.85 0.0207 79.09)", "oklch(0.95 0.0208 79.09)"]
+      }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display", "purpose": "Hero headline, once per page. Always text-wrap: balance." },
+      "headline": { "displayName": "Headline", "purpose": "Section headings on the landing page; inner pages run a quieter parallel scale." },
+      "title": { "displayName": "Title", "purpose": "Card titles. 16.5px baseline, stepping to 19px featured and 22px conference, 13px in calendar cells." },
+      "body": { "displayName": "Body", "purpose": "All reading copy in DM Sans. Loosens to 1.6 on inner pages and 1.8 in event descriptions." },
+      "label": { "displayName": "Label", "purpose": "Uppercase Baloo 2 kickers in coral, plus date badges, day-of-week heads, and footer column heads at 10-13px." }
+    },
+    "categoryHues": {
+      "note": "Category colors are generated, never hand-authored. One hue per category; lightness and chroma are fixed across all categories.",
+      "source": "src/components/landing/utils.ts",
+      "formula": { "background": "oklch(0.94 0.06 H)", "foreground": "oklch(0.42 0.12 H)", "dot": "oklch(0.62 0.15 H)" },
+      "hues": { "Development": 168, "Technology": 192, "Cloud": 200, "Design": 280, "Community": 150, "default": 195 }
+    },
+    "shadows": [
+      { "name": "shadow-sm", "value": "0 2px 8px rgba(7,49,74,.06)", "purpose": "Resting containers and the condensed sticky header. Barely there by design." },
+      { "name": "shadow", "value": "0 14px 40px -16px rgba(7,49,74,.28)", "purpose": "The hover lift. Applied as a card rises 2-5px, with its border handing off to transparent." },
+      { "name": "shadow-lg", "value": "0 30px 70px -24px rgba(7,49,74,.4)", "purpose": "Elements floating above an illustration. Currently only the Submit card's chip." },
+      { "name": "coral-glow", "value": "0 8px 20px -8px color-mix(in srgb, #FF6F59 70%, transparent)", "purpose": "The primary button's own shadow, tinted with its own color rather than navy." },
+      { "name": "coral-glow-hover", "value": "0 14px 26px -10px color-mix(in srgb, #FF6F59 75%, transparent)", "purpose": "Primary button hover state." },
+      { "name": "focus-ring", "value": "0 0 0 4px color-mix(in srgb, #0AB6D6 18%, transparent)", "purpose": "Input focus. Never remove an outline without replacing it with this." }
+    ],
+    "motion": [
+      { "name": "control", "value": "150ms ease", "purpose": "Buttons, chips, inputs, nav, social icons. The default." },
+      { "name": "card-lift", "value": "150ms (transform, box-shadow, border-color)", "purpose": "Card hover rise of -2px to -5px; group cards translate +3px on X instead." },
+      { "name": "calendar-cell", "value": "120ms (transform, box-shadow)", "purpose": "Week and month event cells. Faster because they are small and numerous." },
+      { "name": "nav-underline", "value": "200ms ease on `right`", "purpose": "The 2px tide bar wipes in from the left; driven by aria-current for the active state." },
+      { "name": "header-condense", "value": "250ms ease (background, box-shadow, padding)", "purpose": "Sticky header condensing on scroll, plus the brand logo fade-in." },
+      { "name": "image-zoom", "value": "300ms ease", "purpose": "Feature card image scale to 1.05 on hover." },
+      { "name": "wave-pulse", "value": "5s ease-in-out infinite (scale 1 to 1.08)", "purpose": "The Submit card's radial wave. Disabled under prefers-reduced-motion." }
+    ],
+    "breakpoints": [
+      { "name": "grid-single", "value": "480px" },
+      { "name": "form-stack", "value": "560px" },
+      { "name": "calendar-compact", "value": "640px" },
+      { "name": "submit-stack", "value": "720px" },
+      { "name": "nav-burger", "value": "760px" },
+      { "name": "hero-stack", "value": "860px" },
+      { "name": "header-social-hide", "value": "920px" },
+      { "name": "footer-cols", "value": "960px" },
+      { "name": "container-max", "value": "1200px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The single primary action on a screen. Coral fill with a navy label, never white.",
+      "html": "<button class=\"ds-btn-primary\">Get the digest</button>",
+      "css": ".ds-btn-primary { background: var(--accent, #FF6F59); color: var(--deep, #07314A); border: none; font-family: var(--font-head, 'Baloo 2', system-ui, sans-serif); font-weight: 700; font-size: 16px; padding: 13px 22px; border-radius: 999px; cursor: pointer; box-shadow: 0 8px 20px -8px color-mix(in srgb, var(--accent, #FF6F59) 70%, transparent); transition: transform .15s ease, box-shadow .15s ease, filter .15s ease; } .ds-btn-primary:hover { transform: translateY(-2px); box-shadow: 0 14px 26px -10px color-mix(in srgb, var(--accent, #FF6F59) 75%, transparent); filter: brightness(1.04); } .ds-btn-primary:focus-visible { outline: 2px solid var(--deep, #07314A); outline-offset: 3px; } .ds-btn-primary:active { transform: translateY(0); }"
+    },
+    {
+      "name": "Ghost Button",
+      "kind": "button",
+      "refersTo": "button-ghost",
+      "description": "Secondary action. White fill with a warm hairline border that shifts to tide on hover.",
+      "html": "<button class=\"ds-btn-ghost\">Browse all groups</button>",
+      "css": ".ds-btn-ghost { background: #fff; color: var(--deep, #07314A); border: 1.5px solid var(--line, #e7ded0); font-family: var(--font-head, 'Baloo 2', system-ui, sans-serif); font-weight: 700; font-size: 15px; padding: 11px 20px; border-radius: 999px; cursor: pointer; transition: all .15s ease; } .ds-btn-ghost:hover { border-color: var(--tide, #0AB6D6); color: var(--tide, #0AB6D6); } .ds-btn-ghost:focus-visible { outline: 2px solid var(--tide, #0AB6D6); outline-offset: 2px; }"
+    },
+    {
+      "name": "Filter Chip",
+      "kind": "chip",
+      "refersTo": "chip",
+      "description": "Unselected category filter with a nested count badge. Border shifts to tide on hover.",
+      "html": "<button class=\"ds-chip\">Development <span class=\"ds-chip-count\">12</span></button>",
+      "css": ".ds-chip { font-family: var(--font-head, 'Baloo 2', system-ui, sans-serif); font-weight: 600; font-size: 14.5px; padding: 8px 15px; border-radius: 999px; border: 1.5px solid var(--line, #e7ded0); background: #fff; color: var(--deep, #07314A); cursor: pointer; transition: all .15s ease; display: inline-flex; align-items: center; gap: 7px; } .ds-chip:hover { border-color: var(--tide, #0AB6D6); } .ds-chip:focus-visible { outline: 2px solid var(--tide, #0AB6D6); outline-offset: 2px; } .ds-chip-count { font-size: 12px; background: color-mix(in srgb, var(--tide, #0AB6D6) 16%, #fff); color: var(--deep, #07314A); padding: 1px 7px; border-radius: 999px; font-weight: 700; }"
+    },
+    {
+      "name": "Filter Chip — Active",
+      "kind": "chip",
+      "refersTo": "chip-active",
+      "description": "Selected filter. Inverts entirely to a navy fill; the count badge flips to white-at-20%.",
+      "html": "<button class=\"ds-chip-active\">All <span class=\"ds-chip-active-count\">44</span></button>",
+      "css": ".ds-chip-active { font-family: var(--font-head, 'Baloo 2', system-ui, sans-serif); font-weight: 600; font-size: 14.5px; padding: 8px 15px; border-radius: 999px; border: 1.5px solid var(--deep, #07314A); background: var(--deep, #07314A); color: #fff; cursor: pointer; transition: all .15s ease; display: inline-flex; align-items: center; gap: 7px; } .ds-chip-active:focus-visible { outline: 2px solid var(--tide, #0AB6D6); outline-offset: 2px; } .ds-chip-active-count { font-size: 12px; background: rgba(255,255,255,.2); color: #fff; padding: 1px 7px; border-radius: 999px; font-weight: 700; }"
+    },
+    {
+      "name": "Text Input",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "Fully pilled field. Focus shifts the border to tide and adds a 4px tide ring at 18%.",
+      "html": "<input class=\"ds-input\" type=\"email\" placeholder=\"you@email.com\" aria-label=\"Email address\" />",
+      "css": ".ds-input { font-family: var(--font-body, 'DM Sans', system-ui, sans-serif); font-size: 16px; padding: 13px 16px; border-radius: 999px; border: 1.5px solid var(--line, #e7ded0); background: #fff; color: var(--ink, #0c2536); outline: none; min-width: 260px; transition: border-color .15s, box-shadow .15s; } .ds-input::placeholder { color: var(--muted, #5b7280); } .ds-input:focus { border-color: var(--tide, #0AB6D6); box-shadow: 0 0 0 4px color-mix(in srgb, var(--tide, #0AB6D6) 18%, transparent); }"
+    },
+    {
+      "name": "Event Card",
+      "kind": "card",
+      "refersTo": "card-event",
+      "description": "The system's core object: date badge, category badge, urgency pill, title, group, and tags. Flat at rest, lifting 3px on hover as the border hands off to the shadow.",
+      "html": "<a class=\"ds-event-card\" href=\"#\"><div class=\"ds-ec-date\"><span class=\"ds-ec-dow\">Tue</span><span class=\"ds-ec-day\">12</span><span class=\"ds-ec-mon\">Aug</span><span class=\"ds-ec-time\">6 PM</span></div><div class=\"ds-ec-body\"><div class=\"ds-ec-top\"><span class=\"ds-cat-badge\"><span class=\"ds-cat-dot\"></span>Development</span><span class=\"ds-ec-rel\">Tomorrow</span></div><div class=\"ds-ec-title\">Build and Demo Night</div><div class=\"ds-ec-group\">757 Developers</div><div class=\"ds-ec-tags\"><span class=\"ds-ec-tag\">JavaScript</span><span class=\"ds-ec-tag\">Open Source</span></div></div><span class=\"ds-ec-arrow\">→</span></a>",
+      "css": ".ds-event-card { display: flex; gap: 16px; padding: 18px; background: #fff; border: 1px solid var(--line, #e7ded0); border-radius: 18px; align-items: flex-start; position: relative; text-decoration: none; max-width: 420px; transition: transform .15s, box-shadow .15s, border-color .15s; } .ds-event-card:hover { transform: translateY(-3px); box-shadow: 0 14px 40px -16px rgba(7,49,74,.28); border-color: transparent; } .ds-event-card:focus-visible { outline: 2px solid var(--tide, #0AB6D6); outline-offset: 3px; } .ds-ec-date { flex-shrink: 0; width: 64px; text-align: center; background: var(--sand-soft, #FBF6EC); border-radius: 14px; padding: 9px 0 7px; line-height: 1; } .ds-ec-dow { display: block; font-size: 11px; font-weight: 700; color: var(--coral, #FF6F59); text-transform: uppercase; letter-spacing: .05em; } .ds-ec-day { display: block; font-family: var(--font-head, 'Baloo 2', system-ui, sans-serif); font-weight: 800; font-size: 25px; color: var(--deep, #07314A); margin: 3px 0; } .ds-ec-mon { display: block; font-size: 11px; font-weight: 600; color: var(--muted, #5b7280); text-transform: uppercase; } .ds-ec-time { display: block; font-family: var(--font-head, 'Baloo 2', system-ui, sans-serif); font-size: 11px; font-weight: 700; color: var(--deep-2, #0a4a70); white-space: nowrap; margin-top: 6px; padding-top: 6px; border-top: 1px solid color-mix(in srgb, var(--line, #e7ded0) 75%, transparent); } .ds-ec-body { flex: 1; min-width: 0; } .ds-ec-top { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; } .ds-cat-badge { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-head, 'Baloo 2', system-ui, sans-serif); font-weight: 700; font-size: 11px; padding: 3px 10px; border-radius: 999px; background: oklch(0.94 0.06 168); color: oklch(0.42 0.12 168); } .ds-cat-dot { width: 7px; height: 7px; border-radius: 50%; background: oklch(0.62 0.15 168); } .ds-ec-rel { font-family: var(--font-head, 'Baloo 2', system-ui, sans-serif); font-size: 11.5px; font-weight: 700; color: var(--coral, #FF6F59); text-transform: uppercase; letter-spacing: .04em; margin-left: auto; background: color-mix(in srgb, var(--coral, #FF6F59) 12%, #fff); padding: 2px 9px; border-radius: 999px; } .ds-ec-title { font-family: var(--font-head, 'Baloo 2', system-ui, sans-serif); font-weight: 700; font-size: 16.5px; color: var(--deep, #07314A); line-height: 1.25; } .ds-ec-group { font-size: 13.5px; font-family: var(--font-body, 'DM Sans', system-ui, sans-serif); color: var(--muted, #5b7280); margin: 4px 0 9px; } .ds-ec-tags { display: flex; flex-wrap: wrap; gap: 6px; } .ds-ec-tag { font-family: var(--font-body, 'DM Sans', system-ui, sans-serif); font-size: 11.5px; font-weight: 600; color: var(--deep-2, #0a4a70); background: color-mix(in srgb, var(--seafoam, #5FD0BE) 20%, #fff); padding: 3px 9px; border-radius: 999px; } .ds-ec-arrow { position: absolute; top: 16px; right: 16px; color: var(--tide, #0AB6D6); font-weight: 700; opacity: 0; transform: translateX(-4px); transition: all .15s; } .ds-event-card:hover .ds-ec-arrow { opacity: 1; transform: translateX(0); }"
+    },
+    {
+      "name": "Category Badge",
+      "kind": "chip",
+      "refersTo": "chip",
+      "description": "Generated from one hue per category at fixed lightness and chroma. Always paired with its dot — the dot is what makes it legible at a glance.",
+      "html": "<span class=\"ds-cat ds-cat-dev\"><span class=\"ds-cat-d\"></span>Development</span> <span class=\"ds-cat ds-cat-tech\"><span class=\"ds-cat-d\"></span>Technology</span> <span class=\"ds-cat ds-cat-cloud\"><span class=\"ds-cat-d\"></span>Cloud</span> <span class=\"ds-cat ds-cat-design\"><span class=\"ds-cat-d\"></span>Design</span>",
+      "css": ".ds-cat { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-head, 'Baloo 2', system-ui, sans-serif); font-weight: 700; font-size: 12px; padding: 3px 10px; border-radius: 999px; margin-right: 6px; } .ds-cat-d { width: 7px; height: 7px; border-radius: 50%; } .ds-cat-dev { background: oklch(0.94 0.06 168); color: oklch(0.42 0.12 168); } .ds-cat-dev .ds-cat-d { background: oklch(0.62 0.15 168); } .ds-cat-tech { background: oklch(0.94 0.06 192); color: oklch(0.42 0.12 192); } .ds-cat-tech .ds-cat-d { background: oklch(0.62 0.15 192); } .ds-cat-cloud { background: oklch(0.94 0.06 200); color: oklch(0.42 0.12 200); } .ds-cat-cloud .ds-cat-d { background: oklch(0.62 0.15 200); } .ds-cat-design { background: oklch(0.94 0.06 280); color: oklch(0.42 0.12 280); } .ds-cat-design .ds-cat-d { background: oklch(0.62 0.15 280); }"
+    },
+    {
+      "name": "Navigation Link",
+      "kind": "nav",
+      "refersTo": "nav-link",
+      "description": "Baloo 2 at 82% opacity with a 2px tide underline that wipes in from the left. The active state is driven by aria-current so the visual and assistive signals cannot drift apart.",
+      "html": "<nav class=\"ds-nav\"><a href=\"#\">Events</a><a href=\"#\" aria-current=\"page\">This Week</a><a href=\"#\">Groups</a></nav>",
+      "css": ".ds-nav { display: flex; gap: 28px; font-family: var(--font-head, 'Baloo 2', system-ui, sans-serif); } .ds-nav a { font-weight: 600; font-size: 15.5px; color: var(--deep, #07314A); position: relative; padding: 4px 0; opacity: .82; text-decoration: none; transition: opacity .15s; } .ds-nav a:hover { opacity: 1; } .ds-nav a::after { content: \"\"; position: absolute; left: 0; right: 100%; bottom: -2px; height: 2px; background: var(--tide, #0AB6D6); transition: right .2s ease; border-radius: 2px; } .ds-nav a:hover::after { right: 0; } .ds-nav a[aria-current=\"page\"] { opacity: 1; color: var(--deep-2, #0a4a70); } .ds-nav a[aria-current=\"page\"]::after { right: 0; } .ds-nav a:focus-visible { outline: 2px solid var(--tide, #0AB6D6); outline-offset: 4px; border-radius: 2px; }"
+    },
+    {
+      "name": "Wave Divider",
+      "kind": "custom",
+      "refersTo": "wave-divider",
+      "description": "The system's signature silhouette. One hand-tuned path, full-bleed, stretched rather than cropped. Its fill is the color of the section below, so the wave reads as that section rising into this one. Always aria-hidden.",
+      "html": "<div class=\"ds-wave-demo\"><svg class=\"ds-wave\" viewBox=\"0 0 1440 120\" preserveAspectRatio=\"none\" aria-hidden=\"true\"><path fill=\"#F2E6CE\" d=\"M0,64 C180,112 340,16 540,40 C760,66 900,118 1120,92 C1280,73 1380,40 1440,30 L1440,120 L0,120 Z\"></path></svg></div>",
+      "css": ".ds-wave-demo { position: relative; height: 140px; background: #fff; overflow: hidden; border-radius: 12px; } .ds-wave { position: absolute; bottom: -1px; left: 0; width: 100%; height: 110px; display: block; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Tide Chart",
+    "overview": "A tide chart is a beautiful, useful object whose entire subject is when. It doesn't argue, it doesn't sell, and it never makes you hunt: it lays out what's coming in, in order, so you can plan your day around it. That is what this system is. Every surface answers a newcomer's first question — what can I go to this week? — and the design's job is to make that answer immediate, warm, and worth returning to on a Monday.\n\nThe world is Hampton Roads' actual coast, not a generic beach: deep harbor navy under warm sand, cut by a bright tide cyan and punctuated with coral. Headings are set in Baloo 2, a rounded display face with real warmth to it, over DM Sans for anything you actually read. Corners are generous — cards at 18px, panels at 22px, and every pill and control fully rounded — so the page feels handmade and welcoming rather than engineered. Wave dividers carry one section into the next, which is the system's signature move: sections don't butt against each other, they wash into each other.\n\nNothing floats until you reach for it. Surfaces sit flat on sand-tinted borders and rise on hover with a navy-tinted shadow — the buoyancy is a response, not decoration. The result should read as a community bulletin kept by people who live here, never as a SaaS product page. It is run by volunteers under a 501(c)(3) and it should look like it was made with care by locals, because it was.",
+    "keyCharacteristics": [
+      "Warm sand grounds; deep harbor navy for text and authority",
+      "Rounded, buoyant geometry — 12–28px corners, fully-pilled controls",
+      "Baloo 2 display over DM Sans body: friendly, never corporate",
+      "Coral reserved for now; tide cyan for navigation and interaction",
+      "Flat at rest, lifting on touch — depth is feedback, not ornament",
+      "Wave dividers as the connective tissue between sections",
+      "Category color derived programmatically in OKLCH, with sRGB fallbacks"
+    ],
+    "rules": [
+      { "name": "The One Hue Rule", "body": "A new category means adding one hue number to CATEGORY_META — never a new hand-authored color. Fixed lightness and chroma across all categories is what keeps twenty groups from looking like a bag of candy.", "section": "colors" },
+      { "name": "The Coral Means Now Rule", "body": "Coral marks time, and one action. Today markers, urgency pills, next-up labels, section kickers that announce what's below, and the single primary button on a screen. Never use coral for decoration, for a second competing CTA, or for a category. When everything is urgent, nothing is.", "section": "colors" },
+      { "name": "The Navy-On-Coral Rule", "body": "Coral buttons carry navy labels, never white. White on #FF6F59 measures 2.74:1 — well under the 4.5:1 floor — while #07314A on the same coral measures 4.96:1. Darkening the coral enough to carry white would visibly shift the brand hue toward red, so the label moves instead of the brand.", "section": "colors" },
+      { "name": "The Warm Line Rule", "body": "Borders are --line, a warm sand-grey. Never #ddd, never a neutral grey, never rgba(0,0,0,0.1). One cool border in a sand-toned card is instantly visible and reads as a bug.", "section": "colors" },
+      { "name": "The Two Voices Rule", "body": "Baloo 2 speaks; DM Sans informs. Headings, buttons, labels, dates, times, and chips are Baloo 2. Sentences and paragraphs are DM Sans. A component that mixes them within one line is almost always wrong.", "section": "typography" },
+      { "name": "The No Fallback Font Rule", "body": "Never let a component reset to system-ui or a native font stack. Both faces load from Google Fonts in the layout head with display=swap; a component that opts out breaks the pairing everywhere it appears.", "section": "typography" },
+      { "name": "The Auto-Fit Rule", "body": "New grids use repeat(auto-fill, minmax(<min>, 1fr)) with a real minimum, not a fixed column count with breakpoint overrides. The column count is an outcome, not a decision.", "section": "layout" },
+      { "name": "The Reach-For-It Rule", "body": "Shadow is feedback. If an element can't be clicked, hovered, or focused, it doesn't get a shadow — it gets a border.", "section": "elevation" },
+      { "name": "The Border Handoff Rule", "body": "When a card takes its hover shadow, its border goes transparent in the same transition. Shadow and border never both define the edge.", "section": "elevation" },
+      { "name": "The Pill-Or-Panel Rule", "body": "If it's a control, it's a pill (999px). If it's a surface, it's a panel (12–28px, scaled to its size). There is no middle radius for controls.", "section": "shapes" }
+    ],
+    "dos": [
+      "Do put every new color, font, radius, and shadow through src/styles/tokens.css. It exists because the site previously shipped two palettes and read as two products.",
+      "Do give coral to time and to one action per screen — today markers, urgency pills, next-up labels, kickers, the primary CTA.",
+      "Do label coral buttons in --deep navy (4.96:1), never white (2.74:1).",
+      "Do tint shadows with harbor navy rgba(7,49,74,…).",
+      "Do start surfaces flat with a 1px --line border and add elevation on hover, handing the border off to transparent as the shadow arrives.",
+      "Do pill every control at 999px and scale surface radii to surface size (12–28px).",
+      "Do add a category by adding one hue to CATEGORY_META in landing/utils.ts.",
+      "Do ship both the sRGB hex and the OKLCH value, hex first, when writing color into an inline style attribute.",
+      "Do drive active navigation from aria-current=\"page\" so the visual and assistive signals stay welded together.",
+      "Do use real 757 photography, cached Meetup group images, or the wave and dot-grid motifs when a surface needs an image.",
+      "Do honor prefers-reduced-motion on anything that loops — the Submit card's pulsing wave already does.",
+      "Do underline links inside prose. Color alone measured 1.87:1 against surrounding text, under the 3:1 minimum."
+    ],
+    "donts": [
+      "Don't use generic stock photography. The Unsplash beach and conference images currently in KeepSurfing.astro and the FeatureCard calls on /calendar, /conferences, and /meetups are an anti-reference, not a pattern: a site about a specific local community must not be illustrated with a stranger's stock beach.",
+      "Don't reproduce the pre-token component style. Card.astro, FeatureCard.astro, StatCard.astro, SectionDivider.astro, and NewsletterSignup.astro still use 8–12px radii, generic 0 4px 6px rgba(0,0,0,0.1) black shadows, and — in NewsletterSignup — a system-ui font stack and a hardcoded rgba(0,149,255,.15) focus ring that isn't tide. These are drift to be migrated, not precedent.",
+      "Don't let a component reset the font stack to system-ui or a native stack.",
+      "Don't use neutral grey or black borders and shadows anywhere.",
+      "Don't put white text on coral at body size.",
+      "Don't hand-author a category color, or vary lightness and chroma between categories.",
+      "Don't give a resting shadow to something clickable, or a shadow at all to something that isn't interactive and isn't a container.",
+      "Don't add a fixed-column grid with breakpoint overrides where auto-fill + minmax() would do.",
+      "Don't scope landing calendar styles to a component. The week and month views build their DOM at runtime, and Astro's scoped-style hashing only tags build-time elements — that CSS must stay global in landing.css.",
+      "Don't use a middle radius on a control. Controls are pills; there is no 8px button."
+    ]
+  }
+}

--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["src/layouts/LandingLayout.astro", "src/layouts/MainLayout.astro"],
+  "insertBefore": "</body>",
+  "commentSyntax": "html",
+  "cspChecked": true
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,444 @@
+---
+name: 757tech
+description: The coastal design system for the front door to tech in Hampton Roads.
+colors:
+  deep: "#07314A"
+  deep-2: "#0a4a70"
+  tide: "#0AB6D6"
+  seafoam: "#5FD0BE"
+  coral: "#FF6F59"
+  sand: "#F2E6CE"
+  sand-soft: "#FBF6EC"
+  ink: "#0c2536"
+  muted: "#5b7280"
+  line: "#e7ded0"
+typography:
+  display:
+    fontFamily: "Baloo 2, system-ui, sans-serif"
+    fontSize: "clamp(38px, 6vw, 72px)"
+    fontWeight: 800
+    lineHeight: 1.04
+    letterSpacing: "-0.01em"
+  headline:
+    fontFamily: "Baloo 2, system-ui, sans-serif"
+    fontSize: "clamp(30px, 4vw, 46px)"
+    fontWeight: 800
+    lineHeight: 1.04
+    letterSpacing: "-0.01em"
+  title:
+    fontFamily: "Baloo 2, system-ui, sans-serif"
+    fontSize: "16.5px"
+    fontWeight: 700
+    lineHeight: 1.25
+  body:
+    fontFamily: "DM Sans, system-ui, sans-serif"
+    fontSize: "16px"
+    fontWeight: 400
+    lineHeight: 1.5
+  label:
+    fontFamily: "Baloo 2, system-ui, sans-serif"
+    fontSize: "13.5px"
+    fontWeight: 700
+    letterSpacing: "0.1em"
+rounded:
+  tile: "12px"
+  badge: "14px"
+  mark: "16px"
+  card: "18px"
+  feature: "20px"
+  panel: "22px"
+  billboard: "28px"
+  chip: "999px"
+spacing:
+  tight: "8px"
+  snug: "12px"
+  base: "16px"
+  card: "18px"
+  gutter: "28px"
+  section: "clamp(64px, 9vw, 104px)"
+components:
+  button-primary:
+    backgroundColor: "{colors.coral}"
+    textColor: "{colors.deep}"
+    typography: "{typography.label}"
+    rounded: "{rounded.chip}"
+    padding: "13px 22px"
+  button-ghost:
+    backgroundColor: "#ffffff"
+    textColor: "{colors.deep}"
+    rounded: "{rounded.chip}"
+    padding: "11px 20px"
+  button-ghost-dark:
+    backgroundColor: "transparent"
+    textColor: "#ffffff"
+    rounded: "{rounded.chip}"
+    padding: "13px 22px"
+  chip:
+    backgroundColor: "#ffffff"
+    textColor: "{colors.deep}"
+    rounded: "{rounded.chip}"
+    padding: "8px 15px"
+  chip-active:
+    backgroundColor: "{colors.deep}"
+    textColor: "#ffffff"
+    rounded: "{rounded.chip}"
+    padding: "8px 15px"
+  input:
+    backgroundColor: "#ffffff"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.chip}"
+    padding: "13px 16px"
+  card-event:
+    backgroundColor: "#ffffff"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.card}"
+    padding: "18px"
+  date-badge:
+    backgroundColor: "{colors.sand-soft}"
+    textColor: "{colors.deep}"
+    rounded: "{rounded.badge}"
+    padding: "9px 0 7px"
+    width: "64px"
+---
+
+# Design System: 757tech
+
+## Overview
+
+**Creative North Star: "The Tide Chart"**
+
+A tide chart is a beautiful, useful object whose entire subject is *when*. It doesn't
+argue, it doesn't sell, and it never makes you hunt: it lays out what's coming in, in
+order, so you can plan your day around it. That is what this system is. Every surface
+answers a newcomer's first question — *what can I go to this week?* — and the design's job
+is to make that answer immediate, warm, and worth returning to on a Monday.
+
+The world is Hampton Roads' actual coast, not a generic beach: deep harbor navy under warm
+sand, cut by a bright tide cyan and punctuated with coral. Headings are set in Baloo 2, a
+rounded display face with real warmth to it, over DM Sans for anything you actually read.
+Corners are generous — cards at 18px, panels at 22px, and every pill and control fully
+rounded — so the page feels handmade and welcoming rather than engineered. Wave dividers
+carry one section into the next, which is the system's signature move: sections don't butt
+against each other, they wash into each other.
+
+Nothing floats until you reach for it. Surfaces sit flat on sand-tinted borders and rise on
+hover with a navy-tinted shadow — the buoyancy is a *response*, not decoration. The result
+should read as a community bulletin kept by people who live here, never as a SaaS product
+page. It is run by volunteers under a 501(c)(3) and it should look like it was made with
+care by locals, because it was.
+
+**Key Characteristics:**
+- Warm sand grounds; deep harbor navy for text and authority
+- Rounded, buoyant geometry — 12–28px corners, fully-pilled controls
+- Baloo 2 display over DM Sans body: friendly, never corporate
+- Coral reserved for *now*; tide cyan for navigation and interaction
+- Flat at rest, lifting on touch — depth is feedback, not ornament
+- Wave dividers as the connective tissue between sections
+- Category color derived programmatically in OKLCH, with sRGB fallbacks
+
+## Colors
+
+A coastal palette read at low tide: warm sand light, deep harbor dark, with cyan and coral
+as the two things that catch your eye.
+
+### Primary
+- **Harbor Navy** (`--deep`): The system's authority. Every heading, every high-contrast
+  surface, the active filter chip, the conference month tag, and the label on the coral
+  button. Also the base of the two dark bands (Submit and Newsletter), where it gradients
+  toward a slightly lighter harbor blue.
+- **Deep Water** (`--deep-2`): Navy's readable sibling. Body links on inner pages, event
+  times, tag text, and the current-page nav marker. Use it wherever navy would be too heavy
+  but muted would be too quiet.
+
+### Secondary
+- **Tide Cyan** (`--tide`): The interaction color. Focus rings, hover borders, the nav
+  underline that wipes in from the left, the "757" highlight in the hero headline, link
+  hovers, and the default left-edge stripe on calendar events. If something responds to
+  you, it responds in tide.
+- **Seafoam** (`--seafoam`): The soft counterpart. Text selection background, tag chip
+  fills at 20% over white, the light-on-dark kicker, and the radial core of the Submit
+  card's animated wave.
+
+### Tertiary
+- **Signal Coral** (`--coral`, aliased as `--accent`): The color of *now*. Today markers,
+  "Today" and "Tomorrow" pills, the next-up peek label, section kickers, and the single
+  primary action on any screen.
+
+### Neutral
+- **Warm Sand** (`--sand`): Conference tag fills and the default wave-divider fill. The
+  warmest surface in the system.
+- **Sea Foam Paper** (`--sand-soft`): The workhorse background. Hero gradients, date
+  badges, week and month calendar cells, the view-toggle track, and the conferences band.
+- **Squid Ink** (`--ink`): Body text. Slightly warmer and softer than pure navy so long
+  reading doesn't feel severe.
+- **Driftwood Grey** (`--muted`): Secondary text — group names, locations, timestamps,
+  helper copy, empty states.
+- **Shell Line** (`--line`): Every border in the system. Warm rather than grey, which is
+  what keeps outlined cards from reading as clinical.
+
+### Category Hues
+Event and group categories are **generated, not hand-picked**. `landing/utils.ts` holds one
+hue per category (Development 168°, Technology 192°, Cloud 200°, Design 280°, Community
+150°, unknown 195°) and derives three matched values at fixed lightness and chroma:
+background `oklch(0.94 0.06 H)`, foreground `oklch(0.42 0.12 H)`, dot `oklch(0.62 0.15 H)`.
+Every value ships with an sRGB hex fallback computed from the same L/C/H, emitted as a
+double declaration so old browsers keep the hex and modern ones override with OKLCH.
+
+**The One Hue Rule.** A new category means adding one hue number to `CATEGORY_META` — never
+a new hand-authored color. Fixed lightness and chroma across all categories is what keeps
+twenty groups from looking like a bag of candy.
+
+### Named Rules
+
+**The Coral Means Now Rule.** Coral marks time, and one action. Today markers, urgency
+pills, next-up labels, section kickers that announce what's below, and the single primary
+button on a screen. Never use coral for decoration, for a second competing CTA, or for a
+category. When everything is urgent, nothing is.
+
+**The Navy-On-Coral Rule.** Coral buttons carry **navy** labels, never white. White on
+`#FF6F59` measures 2.74:1 — well under the 4.5:1 floor — while `#07314A` on the same coral
+measures 4.96:1. Darkening the coral enough to carry white would visibly shift the brand
+hue toward red, so the label moves instead of the brand.
+
+**The Warm Line Rule.** Borders are `--line`, a warm sand-grey. Never `#ddd`, never a
+neutral grey, never `rgba(0,0,0,0.1)`. One cool border in a sand-toned card is instantly
+visible and reads as a bug.
+
+## Typography
+
+**Display Font:** Baloo 2 (with `system-ui, sans-serif`), weights 500–800
+**Body Font:** DM Sans (with `system-ui, sans-serif`), optical-sized 9–40, weights 400–700
+**Mono:** DM Mono (with `ui-monospace, monospace`) — used only for the conference photo
+placeholder label
+
+**Character:** Baloo 2 is round, slightly chunky, and unmistakably friendly — it does the
+work of making a directory of events feel like an invitation rather than a database. DM
+Sans underneath is quiet and highly legible at small sizes, which is what lets event cards
+carry a title, group, time, and three tags without turning into noise. The pairing is warm
+on top, efficient underneath.
+
+### Hierarchy
+- **Display** (800, `clamp(38px, 6vw, 72px)`, 1.04): The hero headline, once per page.
+  Always `text-wrap: balance` — an orphaned word in a 72px heading is very visible.
+- **Headline** (800, `clamp(30px, 4vw, 46px)`, 1.04): Section headings. Inner pages run a
+  quieter parallel scale (`clamp(2rem, 5vw, 3rem)` for h1, `clamp(1.4rem, 3vw, 1.9rem)` for
+  h2) at line-height 1.15.
+- **Title** (700, 16.5px, 1.25): Card titles. Steps up to 19px on featured cards and 22px
+  on conference cards; drops to 13px inside calendar cells.
+- **Body** (400, 16px, 1.5): All reading copy in DM Sans. Prose contexts loosen — inner
+  pages run 1.6, and event descriptions run 1.8 so inline links clear the 24px touch-target
+  minimum. Lead paragraphs cap at 440–560px.
+- **Label** (700, 13.5px, `0.1em`, uppercase): Section kickers in coral. The system's
+  smaller labels — date badges, day-of-week headers, footer column heads — run 10–13px at
+  `0.04–0.08em`, always Baloo 2, always uppercase.
+
+### Named Rules
+
+**The Two Voices Rule.** Baloo 2 speaks; DM Sans informs. Headings, buttons, labels, dates,
+times, and chips are Baloo 2. Sentences and paragraphs are DM Sans. A component that mixes
+them within one line is almost always wrong.
+
+**The No Fallback Font Rule.** Never let a component reset to `system-ui` or a native font
+stack. Both faces load from Google Fonts in the layout head with `display=swap`; a
+component that opts out breaks the pairing everywhere it appears.
+
+## Layout
+
+A centered 1200px column with 28px gutters governs the site (the landing hero runs slightly
+narrower at 1160px, and the Submit and Newsletter bands break full-bleed while keeping their
+inner content on the same 1200px rail). Vertical rhythm is one clamped step:
+`clamp(64px, 9vw, 104px)` for landing sections, `clamp(2.5rem, 6vw, 4rem)` for inner-page
+heroes.
+
+Content grids are auto-fitting rather than fixed-column, so density follows the viewport
+instead of a breakpoint table: events at `minmax(380px, 1fr)`, featured at `minmax(330px,
+1fr)`, conferences at `minmax(270px, 1fr)`, groups at `minmax(310px, 1fr)`. The hero is the
+one deliberate asymmetry — a `1.05fr / 0.95fr` split that gives the copy and signup form
+slightly more room than the logo and next-event peek.
+
+Responsive behavior collapses in stages rather than at one breakpoint: the header sheds its
+social icons at 920px and becomes a burger menu at 760px; the hero stacks at 860px, as does
+the week calendar (from seven columns to stacked rows with the day head rotating to a left
+rail); the calendar header becomes a three-column grid at 640px so the reset pill drops to
+its own row; month cells shed event titles at 640px; the event grid goes single-column at
+480px. Sticky-header offset is handled with `scroll-margin-top: 86px` scoped to `section[id]`
+and `#subscribe`.
+
+**The Auto-Fit Rule.** New grids use `repeat(auto-fill, minmax(<min>, 1fr))` with a real
+minimum, not a fixed column count with breakpoint overrides. The column count is an outcome,
+not a decision.
+
+## Elevation & Depth
+
+**Flat at rest, lifting on touch.** Surfaces sit on a 1px `--line` border with no shadow;
+depth appears only as a response to interaction. On hover a card rises 2–5px and takes a
+navy-tinted shadow, and — importantly — its border goes transparent as the shadow arrives,
+so the two never stack into a hard double edge. This is where the system's buoyancy lives:
+things float when you reach for them.
+
+Shadows are tinted with the harbor navy (`rgba(7,49,74,…)`), never neutral black. A black
+shadow under a sand-toned card reads as dirt; the navy tint reads as water.
+
+A small number of resting surfaces carry `--shadow-sm` at rest because they are containers
+rather than targets: the calendar panel, featured cards, the hero's next-event peek, and the
+scrolled header. Everything clickable starts flat.
+
+### Shadow Vocabulary
+- **`--shadow-sm`** (`0 2px 8px rgba(7,49,74,.06)`): Resting containers and the condensed
+  sticky header. Barely there by design.
+- **`--shadow`** (`0 14px 40px -16px rgba(7,49,74,.28)`): The hover lift. The workhorse.
+- **`--shadow-lg`** (`0 30px 70px -24px rgba(7,49,74,.4)`): Reserved for elements floating
+  above an illustration — currently only the Submit card's chip.
+- **Coral glow** (`0 8px 20px -8px color-mix(in srgb, var(--accent) 70%, transparent)`): The
+  primary button's own shadow, tinted with its own color rather than navy, deepening to
+  `0 14px 26px -10px` at 75% on hover.
+
+### Named Rules
+
+**The Reach-For-It Rule.** Shadow is feedback. If an element can't be clicked, hovered, or
+focused, it doesn't get a shadow — it gets a border.
+
+**The Border Handoff Rule.** When a card takes its hover shadow, its border goes
+`transparent` in the same transition. Shadow and border never both define the edge.
+
+## Shapes
+
+Everything is rounded, and the radius encodes scale: the bigger the surface, the softer the
+corner. Small marks and month cells at 12px, date badges at 14px, group marks and inline
+cards at 16px, event cards and content boxes at 18px (`--radius`, the only named radius
+token), conference cards at 20px, calendar and peek panels at 22px, and the Submit
+billboard at 28px. Controls — buttons, chips, inputs, search, view toggles, count badges,
+"Today" pills — are always fully pilled at 999px. Circles are reserved for icon buttons:
+social icons and calendar nav at 38px.
+
+Borders are hairline and warm: 1px `--line` on surfaces, 1.5px on interactive controls so
+buttons and inputs read as touchable. Calendar events add a 3px left stripe in their
+category color — the one place a border carries meaning rather than structure.
+
+The **wave** is the system's signature silhouette: a single hand-tuned SVG path
+(`WaveDivider.astro`, `viewBox="0 0 1440 120"`, `preserveAspectRatio="none"`) absolutely
+positioned at `bottom: -1px` and scaled `clamp(60px, 8vw, 110px)` tall. The `-1px` matters —
+it prevents a subpixel seam between the wave and the section below.
+
+**The Pill-Or-Panel Rule.** If it's a control, it's a pill (999px). If it's a surface, it's
+a panel (12–28px, scaled to its size). There is no middle radius for controls.
+
+## Components
+
+### Buttons
+- **Shape:** Fully pilled (`999px`), Baloo 2 at weight 700.
+- **Primary** (`.btn-coral`): Coral fill, **navy** label (see The Navy-On-Coral Rule),
+  16px, `13px 22px` padding, with its own coral-tinted glow. Hover rises 2px, deepens the
+  glow, and brightens 4%; active returns to 0.
+- **Ghost** (`.btn-ghost`): White fill, navy label, 1.5px `--line` border, 15px,
+  `11px 20px`. Hover shifts both border and label to tide cyan.
+- **Ghost Dark** (`.btn-ghost-dark`): For navy bands. Transparent fill, white label, 1.5px
+  white-at-45% border. Hover fills to white-at-12% and brightens the border to solid.
+- **Transitions:** `.15s ease` on transform, shadow, and filter. Never longer on a button.
+
+### Chips
+- **Filter chips:** White fill, 1.5px `--line` border, navy Baloo 2 at 14.5px, `8px 15px`.
+  Hover shifts the border to tide. **Active** inverts entirely to a navy fill with white
+  text and a navy border.
+- **Count badge:** A nested pill inside the chip — tide at 16% over white, navy text, 12px
+  bold. Inside an active chip it flips to white-at-20% on navy.
+- **Tag chips:** Non-interactive. Seafoam at 20% over white with `--deep-2` text (event
+  tags), or solid `--sand` with `--deep-2` text (conference tags), 11.5px at weight 600.
+- **Category badge:** Generated OKLCH background and foreground plus a 7px dot in the
+  category's dot color. Always paired with its dot; the dot is what makes the category
+  legible at a glance.
+
+### Cards / Containers
+- **Corner Style:** 18px for event cards and content boxes; 20–22px for conference cards
+  and panels.
+- **Background:** White. Sand-soft is for the surfaces *behind* cards, not the cards.
+- **Shadow Strategy:** Flat at rest, `--shadow` on hover with the border handing off to
+  transparent (see Elevation).
+- **Border:** 1px `--line`.
+- **Internal Padding:** 18px on event and conference cards, 22px on panels,
+  `clamp(1.25rem, 3vw, 2rem)` on content boxes.
+- **Motion:** `translateY(-3px)` for event cards, `-4px` featured, `-5px` conferences.
+  Group cards move sideways instead — `translateX(3px)` — because they're a list, not a
+  grid.
+
+### Inputs / Fields
+- **Style:** White fill, 1.5px `--line` border, fully pilled, DM Sans at 15–16px,
+  `13px 16px` padding. 16px minimum on anything a phone will focus, to prevent iOS zoom.
+- **Focus:** Border shifts to tide cyan plus a 4px ring of tide at 16–18%
+  (`color-mix(in srgb, var(--tide) 18%, transparent)`). Never remove the outline without
+  replacing it with this ring.
+- **Search:** A 38px left inset for the icon and a right-aligned clear button, both
+  `--muted`.
+
+### Navigation
+- Baloo 2 at 15.5px weight 600, navy at 82% opacity, rising to full on hover.
+- **The underline wipe:** a 2px tide bar pinned to the left that animates `right: 100% → 0`
+  over `.2s`. It is driven by `aria-current="page"` for the active state, so the visual
+  marker and the accessibility signal cannot drift apart.
+- **Scroll behavior:** transparent at rest over the hero, condensing at scroll to
+  white-at-88% with a 12px backdrop blur, a `--line` hairline, and reduced padding. The
+  brand logo is hidden at the top (the hero already shows it large) and fades in as the
+  header condenses. Inner pages start in the condensed state, since there's no hero behind
+  the bar.
+- **Mobile (≤760px):** burger toggle; the nav drops as a blurred white sheet with 10px
+  rounded rows, `--sand-soft` on hover, and the underline disabled.
+
+### Wave Divider (signature)
+One SVG path, full-bleed, `preserveAspectRatio="none"` so it stretches rather than crops.
+Its `fill` prop is set to the color of the section *below* it, so the wave reads as that
+section rising into this one. Defaults to `--sand`. It is `aria-hidden`, always — it carries
+no information.
+
+### Date Badge (signature)
+The system's most-repeated object: a 64px sand-soft tile stacking day-of-week (11px coral,
+uppercase), day number (25px Baloo 2 at 800, navy), month (11px muted, uppercase), and time
+below a hairline rule. In the hero and featured band the whole badge takes the category's
+generated color instead of sand-soft, and the internal rule switches to
+`color-mix(in srgb, currentColor 25%, transparent)` so it tints with whatever it sits on.
+
+## Do's and Don'ts
+
+### Do:
+- **Do** put every new color, font, radius, and shadow through `src/styles/tokens.css`. It
+  exists because the site previously shipped two palettes and read as two products.
+- **Do** give coral to time and to one action per screen — today markers, urgency pills,
+  next-up labels, kickers, the primary CTA.
+- **Do** label coral buttons in `--deep` navy (4.96:1), never white (2.74:1).
+- **Do** tint shadows with harbor navy `rgba(7,49,74,…)`.
+- **Do** start surfaces flat with a 1px `--line` border and add elevation on hover, handing
+  the border off to `transparent` as the shadow arrives.
+- **Do** pill every control at 999px and scale surface radii to surface size (12–28px).
+- **Do** add a category by adding **one hue** to `CATEGORY_META` in `landing/utils.ts`.
+- **Do** ship both the sRGB hex and the OKLCH value, hex first, when writing color into an
+  inline `style` attribute.
+- **Do** drive active navigation from `aria-current="page"` so the visual and assistive
+  signals stay welded together.
+- **Do** use real 757 photography, cached Meetup group images, or the wave and dot-grid
+  motifs when a surface needs an image.
+- **Do** honor `prefers-reduced-motion` on anything that loops — the Submit card's pulsing
+  wave already does.
+- **Do** underline links inside prose. Color alone measured 1.87:1 against surrounding
+  text, under the 3:1 minimum.
+
+### Don't:
+- **Don't** use generic stock photography. The Unsplash beach and conference images
+  currently in `KeepSurfing.astro` and the `FeatureCard` calls on `/calendar`,
+  `/conferences`, and `/meetups` are an **anti-reference**, not a pattern: a site about a
+  specific local community must not be illustrated with a stranger's stock beach.
+- **Don't** reproduce the pre-token component style. `Card.astro`, `FeatureCard.astro`,
+  `StatCard.astro`, `SectionDivider.astro`, and `NewsletterSignup.astro` still use 8–12px
+  radii, generic `0 4px 6px rgba(0,0,0,0.1)` black shadows, and — in NewsletterSignup — a
+  `system-ui` font stack and a hardcoded `rgba(0,149,255,.15)` focus ring that isn't tide.
+  These are **drift to be migrated**, not precedent. New work follows the coastal system.
+- **Don't** let a component reset the font stack to `system-ui` or a native stack.
+- **Don't** use neutral grey or black borders and shadows anywhere.
+- **Don't** put white text on coral at body size.
+- **Don't** hand-author a category color, or vary lightness and chroma between categories.
+- **Don't** give a resting shadow to something clickable, or a shadow at all to something
+  that isn't interactive and isn't a container.
+- **Don't** add a fixed-column grid with breakpoint overrides where `auto-fill` +
+  `minmax()` would do.
+- **Don't** scope landing calendar styles to a component. The week and month views build
+  their DOM at runtime, and Astro's scoped-style hashing only tags build-time elements —
+  that CSS must stay global in `landing.css`.
+- **Don't** use a middle radius on a control. Controls are pills; there is no 8px button.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,128 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+**Primary: the curious newcomer.** Someone new to Hampton Roads, new to tech, or newly
+looking to plug in. They do not know which groups exist, which are alive, or which are for
+them. Their job on this site is narrow and immediate: **"find one thing worth going to this
+week."** Every design decision resolves in their favor when audiences conflict.
+
+Other people demonstrably use the site — regular attendees scanning the full calendar,
+group organizers wanting reach, employers gauging the scene — but they are served, not
+optimized for. Nothing should be built *primarily* for them without revisiting this record.
+
+## Product Purpose
+
+757tech.org is the single front door to tech in Hampton Roads (the "757" — Norfolk,
+Virginia Beach, Chesapeake, Hampton, Newport News and surrounding cities). It aggregates
+every tech meetup, user group, and regional conference in the region into one continuously
+refreshed calendar, then redistributes that calendar as a Monday digest and a weekly
+multi-channel announcement packet.
+
+**Success is digest subscribers.** A good month is one where the Monday newsletter list
+grew. The site is the acquisition surface for that list; the calendar is the reason anyone
+hands over an email address.
+
+## Positioning
+
+Two things a neighboring site could not truthfully copy:
+
+1. **Automated aggregation plus human verification.** Events are pulled from 20 groups'
+   Meetup RSS feeds every six hours, deduplicated across groups, and checked for
+   staleness — then a human confirms each event is still live before it goes into the
+   weekly announcements. Neither a pure scraper nor a hand-maintained list produces this.
+2. **Platform-agnostic scope.** The calendar spans Meetup.com groups, independent regional
+   conferences, Slack, and Discord. No single event platform's directory covers the region
+   the way this does, because no platform can see the others.
+
+Supporting position: it is community infrastructure, not a business — supported by
+RevolutionVA, a 501(c)(3) non-profit, and built by community members.
+
+## Operating Context
+
+- **The six-hour loop.** A GitHub Action refreshes `calendar-events.json` from Meetup RSS
+  feeds four times a day. A scheduled rebuild keeps build-time date math current.
+- **The Monday ritual.** Each Monday a weekly report is generated, every event link is
+  opened and verified as still active and correctly titled/timed, and the confirmed set is
+  published as a Bento digest plus Slack, Discord, LinkedIn, X, and Instagram carousel
+  variants. Verification gates publication — an unverified event does not ship.
+- **Growth by contribution.** New groups enter through `meetups-combined.json` (schema
+  validated, `add-meetup` script) prompted by a submit CTA on the landing page.
+- **Archive.** Past weeks remain browsable; the current week has its own surface.
+
+## Capabilities and Constraints
+
+- Static Astro build, no server and no database. All content lives in JSON data files
+  under `src/data/`, validated against JSON Schema on commit and in CI.
+- Because the site is statically generated, "today" is resolved at build time. Freshness
+  depends on the scheduled rebuild, not on the visitor's clock.
+- Group categories are a fixed set of four: Technology, Development, Cloud, Design.
+- The newsletter is hosted by Bento. The hero form posts directly to a Bento endpoint and
+  redirects to `/newsletter-thank-you`.
+- Every event and group link is outbound to its source (Meetup, conference site). The site
+  never owns RSVP, ticketing, or attendance data and should not appear to.
+- **Confirmed decision: `/work`, `/learning`, and `/communities` are vestigial and will be
+  retired.** All three run on hardcoded placeholder arrays that were never wired to real
+  data; they dilute the site's actual job. *Undecided:* whether each is deleted or
+  redirected, and where any surviving content lands. **Hard constraint on that removal:**
+  the 757dev Slack and Discord entry points currently living on `/communities` must remain
+  reachable elsewhere (they exist today in the footer and on `/get-involved`) — retiring
+  the page must not remove the community's front doors.
+
+## Brand Commitments
+
+- **Name:** 757tech / 757tech.org. The region is referred to as "the 757" and as Hampton
+  Roads.
+- **Voice:** coastal and tidal, warm and plainspoken. Established in live copy: "The front
+  door to tech in the 757", "in one tide", "Keep Surfing", wave dividers between sections.
+  This metaphor is in use and is a commitment, not a suggestion.
+- **Assets:** logo at `public/images/757tech-logo.png`; cached per-group images under
+  `public/images/meetups/`.
+- **Attribution, required in the footer:** "Supported by RevolutionVA, a 501(c)(3)
+  non-profit — built by the community, for the community," crediting Ted Patterson and
+  Kevin Griffin.
+- **Handles:** `@757techorg` on X, Instagram, and Threads; `@757tech.org` on Bluesky;
+  `757tech` on LinkedIn; the 757dev Slack workspace and Discord server.
+
+## Evidence on Hand
+
+Real, in-repo, usable:
+
+- 20 meetup groups with tags, categories, RSS feeds, and cached images
+  (`src/data/meetups-combined.json`)
+- 11 conferences (`src/data/conferences.json`)
+- 54 calendar events, refreshed automatically (`src/data/calendar-events.json`)
+- Generated weekly announcement archives (`weekly-meetups/`) and a browsable weekly archive
+- A weekly social carousel generator (`scripts/generate-weekly-carousel.js`)
+
+**Absences future work must not fabricate:** there are no testimonials, no attendance
+figures, no publishable subscriber count, no sponsors, no pricing, and no employer
+endorsements. Do not invent social proof for this site. If a number is needed, it must be
+sourced and confirmed first.
+
+## Product Principles
+
+1. **Answer "what can I go to this week?" before anything else.** The newcomer's first
+   question outranks completeness, navigation, and brand expression on every surface.
+2. **Every surface earns the subscription.** Success is measured in digest subscribers, so
+   no page is a dead end — the path to the Monday digest is always available and never
+   nagging.
+3. **Completeness is the credibility.** A dead link or a cancelled event costs more trust
+   than a missing feature gains. Verification is a product feature, not overhead.
+4. **Always link out; never impersonate the source.** This is a front door, not a walled
+   garden. Groups keep their identity and their traffic.
+5. **Automation proposes, humans verify.** Nothing reaches the community — site or social
+   — on automation's word alone.
+
+## Accessibility & Inclusion
+
+No product-specific standard has been established. The codebase shows general good
+practice (form `aria-label`s, focus management, `oklch` color with fallbacks) but this is
+convention, not a stated requirement. *Undecided:* whether to formally commit to WCAG 2.2
+AA.

--- a/solo.yml
+++ b/solo.yml
@@ -1,0 +1,11 @@
+# Visit https://soloterm.com to learn more
+name: 757-community-site-public
+icon: null
+processes:
+  Astro:
+    command: yarn run dev
+    working_dir: null
+    auto_start: true
+    auto_restart: true
+    restart_when_changed: []
+    env: {}


### PR DESCRIPTION
Captures today's design-context work so it lives in the repo as shared authority instead of one machine's local state.

## What's in here

| File | What it is |
|---|---|
| `PRODUCT.md` | Product truth from `/impeccable init` — primary user, success metric, durable constraints, and the explicitly-undecided items |
| `DESIGN.md` | The coastal design system, extracted from the existing code by `/impeccable document`. Tokens in frontmatter, ten named rules in prose |
| `.impeccable/design.json` | Machine-readable sidecar: OKLCH tonal ramps, shadows, motion, breakpoints, and 9 rendered component primitives |
| `.impeccable/critique/` | Baseline UX critique snapshot (19/40) that `/impeccable polish` reads as a backlog |
| `.impeccable/config.json` | Detector config, including a waiver for the Bento email script |
| `.github/hooks/impeccable.json` | Team-shared detector hook. Resolves its path via `git rev-parse`, so it's portable |
| `solo.yml` | Solo process config for the Astro dev server |

## Two fixes worth reviewing

**Per-developer state is now properly gitignored.** `.impeccable/config.local.json` and `hook.cache.json` were only excluded through `.git/info/exclude`, which is machine-local. Committing `.impeccable/` without real `.gitignore` entries would have handed every teammate a permanently dirty tree once they ran the skill. Also pre-ignores `.impeccable/live/sessions/`, which is session journal state rather than project source.

**`.cursor/hooks.json` is deliberately excluded, not forgotten.** It embeds an absolute path to the skill under a specific user's home directory, so it only works on one machine and would leak a username into the repo. The GitHub Copilot manifest does the same job portably and is included instead. Cursor users get their manifest regenerated locally by the skill.

## Known issue, not fixed here

`DESIGN.md` prescribes coral (`#FF6F59`) for section kickers and the hero peek label on white. The critique in this same PR measures that pairing at **2.75:1**, under the 4.5:1 AA floor — and the doc contradicts itself, since it also documents the Navy-On-Coral rule for exactly this reason. Left as-is so the doc fix and the token fix land together in a follow-up `/impeccable colorize` pass, rather than half-correcting the guidance now.

Nothing here changes site output — no component, style, or page is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)