### PR TITLE
Make inline-element spacing explicit ahead of Astro 7

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -34,7 +34,7 @@ const RULES = [
   [/^\/weekly\/?$/, { priority: 0.7, changefreq: 'weekly' }],
   [/^\/meetups\/?$/, { priority: 0.9, changefreq: 'weekly' }],
   [/^\/conferences\/?$/, { priority: 0.8, changefreq: 'monthly' }],
-  [/^\/(work|learning|communities|get-involved)\/?$/, { priority: 0.5, changefreq: 'monthly' }],
+  [/^\/get-involved\/?$/, { priority: 0.5, changefreq: 'monthly' }],
 ];
 
 export default defineConfig({

--- a/src/components/landing/LandingFooter.astro
+++ b/src/components/landing/LandingFooter.astro
@@ -62,7 +62,10 @@ const year = new Date().getFullYear();
         until this footer replaced it. Kept rather than dropped so the build
         credit doesn't silently disappear from 11 pages. */}
     <span class="footer-credit">
-      Built by <a href="https://www.linkedin.com/in/tedjpatterson/" target="_blank" rel="noopener noreferrer">Ted Patterson</a>
+      {/* The `{" "}` is load-bearing: Astro 7 strips leading whitespace from a
+          text node following an inline element, so relying on the line break
+          alone renders "Ted Patterson& Kevin Griffin". */}
+      Built by <a href="https://www.linkedin.com/in/tedjpatterson/" target="_blank" rel="noopener noreferrer">Ted Patterson</a>{" "}
       &amp; <a href="https://www.linkedin.com/in/1kevgriff" target="_blank" rel="noopener noreferrer">Kevin Griffin</a>
     </span>
     <span class="footer-tag">Made in Hampton Roads 🌊</span>

--- a/src/pages/get-involved.astro
+++ b/src/pages/get-involved.astro
@@ -64,8 +64,8 @@ import NewsletterSignup from '../components/NewsletterSignup.astro';
         
         <p>
           Not sure if there's enough interest in your topic? Consider reaching out to 
-          <a href="https://www.meetup.com/757dev/" target="_blank" rel="noopener noreferrer">757 Developers on Meetup</a> 
-          to host a session first. It's a great way to test your topic and gauge interest before committing to starting 
+          <a href="https://www.meetup.com/757dev/" target="_blank" rel="noopener noreferrer">757 Developers on Meetup</a>{" "}
+          to host a session first. It's a great way to test your topic and gauge interest before committing to starting{" "}
           your own meetup group.
         </p>
       </div>


### PR DESCRIPTION
Unblocks #277 (Astro 6.4.8 → 7.1.0). Found by diffing the #277 preview against production page-by-page.

## The problem

Astro 7 strips leading whitespace from a text node that follows an inline element. Astro 6 preserved it. Two places relied on a bare line break to separate words, and both regress **visibly**:

**Footer attribution — all 84 pages**

```
Astro 6:  ...>Ted Patterson</a>⏎&amp; <a ...   →  "Ted Patterson & Kevin Griffin"
Astro 7:  ...>Ted Patterson</a>&amp; <a ...    →  "Ted Patterson& Kevin Griffin"
```

This is the credit PRODUCT.md lists as a required brand commitment.

**`/get-involved` body copy — worse**

```
Astro 7:  757 Developers on Meetup</a>to host a session first.
```

Renders as "Meetup**to** host a session" — two words fused mid-sentence.

## The fix

Explicit `{" "}` rather than reflowing the markup, so the space is an expression the minifier can't drop. Correct under **both** v6 and v7 — which is why it lands separately, ahead of the upgrade, instead of inside it.

A scan of every `.astro` file found only these two instances. A third spot in the same paragraph got the same treatment defensively, since removing its trailing space would have traded one fused word pair for another.

## Also

Drops `/work`, `/learning`, `/communities` from the sitemap priority rule in `astro.config.mjs` — dead config left behind by the retirement in #293. The regex simply stopped matching them.

## Verification

- `npm run build` green, 84 pages; both spots emit a real space in `dist/`
- `npm run validate` passes
- Sitemap: retired routes absent, `/get-involved` still present at priority 0.5

## Note for #277

Astro 7 pulls `undici@8.10.0`, which requires **Node ≥ 22.19.0**. Local dev here is on 22.18.0 and `yarn add astro@7` refuses on the engine check. CI's Node is new enough, so the build passes — but merging #277 will break local installs until contributors upgrade Node. Worth calling out in that PR.

Separately: the CVE #277 cites (CVE-2026-73422, reflected XSS via View Transition animation properties) isn't reachable here — the site uses no View Transitions at all. The upgrade is hygiene, not an emergency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBrc5o7ZULLD5r3586LmcN